### PR TITLE
[Y26W2-9] chore(root): biome이 dist 폴더도 제외하도록 수정

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -2,7 +2,7 @@
   "$schema": "./node_modules/@biomejs/biome/configuration_schema.json",
   "files": {
     "ignoreUnknown": true,
-    "includes": ["**", "!**/.direnv", "!**/.next"]
+    "includes": ["**", "!**/dist", "!**/.direnv", "!**/.next"]
   },
   "linter": {
     "domains": {


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- `bimoe`이 `dist` 폴더 내의 번들 output도 함께 린트 및 포매팅하는 경우가 있어서, 이를 수정했습니다. (`packages/ui`에 해당됨)

## ✅ 체크리스트

- [x] 기능 동작 확인
- [ ] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->


<!-- ejoffe/spr end -->
