### PR TITLE
[Y26W2-15] feat(ui): TailwindCSS cn 클래스 유틸 추가

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -16,18 +16,17 @@
     "lint": "biome check ."
   },
   "dependencies": {
+    "clsx": "^2.1.1",
     "react": "^19.1.0",
-    "react-dom": "^19.1.0"
+    "react-dom": "^19.1.0",
+    "tailwind-merge": "^3.3.0"
   },
   "devDependencies": {
     "@tailwindcss/cli": "^4.1.7",
-    "@tailwindcss/postcss": "^4.1.7",
     "@tsconfig/vite-react": "^6.3.5",
     "@types/node": "^22",
     "@types/react": "^19",
     "@types/react-dom": "^19",
-    "postcss": "^8",
-    "postcss-load-config": "*",
     "tailwindcss": "^4.1.7",
     "tsdown": "^0.12.3",
     "typescript": "^5.8.3"

--- a/packages/ui/src/interim-button/index.tsx
+++ b/packages/ui/src/interim-button/index.tsx
@@ -9,7 +9,7 @@ export type InterimButtonProps = PropsWithChildren<
 
 export const InterimButton = ({
   children,
-  className = "",
+  className,
   ...props
 }: InterimButtonProps) => {
   return (

--- a/packages/ui/src/interim-button/index.tsx
+++ b/packages/ui/src/interim-button/index.tsx
@@ -1,4 +1,5 @@
 import type { ButtonHTMLAttributes, PropsWithChildren } from "react";
+import { cn } from "@/utils";
 
 export type InterimButtonProps = PropsWithChildren<
   {
@@ -13,7 +14,10 @@ export const InterimButton = ({
 }: InterimButtonProps) => {
   return (
     <button
-      className={`rounded-lg border border-transparent bg-neutral-900 px-4 py-1.5 font-inherit font-medium text-base text-neutral-100 transition-colors duration-200 hover:border-indigo-400 focus:outline-2 focus:outline-auto focus:outline-blue-400 dark:bg-neutral-100 dark:text-neutral-900 ${className}`}
+      className={cn(
+        "rounded-lg border border-transparent bg-neutral-900 px-4 py-1.5 font-inherit font-medium text-base text-neutral-100 transition-colors duration-200 hover:border-indigo-400 focus:outline-2 focus:outline-auto focus:outline-blue-400 dark:bg-neutral-100 dark:text-neutral-900",
+        className,
+      )}
       {...props}
     >
       {children}

--- a/packages/ui/src/interim-description/index.tsx
+++ b/packages/ui/src/interim-description/index.tsx
@@ -1,4 +1,5 @@
 import type { PropsWithChildren } from "react";
+import { cn } from "@/utils";
 
 export type InterimDescriptionProps = PropsWithChildren<{
   className?: string;
@@ -10,7 +11,7 @@ export const InterimDescription = ({
   ...props
 }: InterimDescriptionProps) => {
   return (
-    <p className={`my-4 text-base ${className}`} {...props}>
+    <p className={cn("my-4 text-base", className)} {...props}>
       {children}
     </p>
   );

--- a/packages/ui/src/interim-description/index.tsx
+++ b/packages/ui/src/interim-description/index.tsx
@@ -7,7 +7,7 @@ export type InterimDescriptionProps = PropsWithChildren<{
 
 export const InterimDescription = ({
   children,
-  className = "",
+  className,
   ...props
 }: InterimDescriptionProps) => {
   return (

--- a/packages/ui/src/interim-title/index.tsx
+++ b/packages/ui/src/interim-title/index.tsx
@@ -7,7 +7,7 @@ export type InterimTitleProps = PropsWithChildren<{
 
 export const InterimTitle = ({
   children,
-  className = "",
+  className,
   ...props
 }: InterimTitleProps) => {
   return (

--- a/packages/ui/src/interim-title/index.tsx
+++ b/packages/ui/src/interim-title/index.tsx
@@ -1,4 +1,5 @@
 import type { PropsWithChildren } from "react";
+import { cn } from "@/utils";
 
 export type InterimTitleProps = PropsWithChildren<{
   className?: string;
@@ -10,7 +11,7 @@ export const InterimTitle = ({
   ...props
 }: InterimTitleProps) => {
   return (
-    <h1 className={`my-8 font-bold text-5xl ${className}`} {...props}>
+    <h1 className={cn("my-8 font-bold text-5xl", className)} {...props}>
       {children}
     </h1>
   );

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -1,0 +1,6 @@
+import { type ClassValue, clsx } from "clsx/lite";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/packages/ui/src/utils/index.ts
+++ b/packages/ui/src/utils/index.ts
@@ -1,4 +1,4 @@
-import { type ClassValue, clsx } from "clsx/lite";
+import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
 export function cn(...inputs: ClassValue[]) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,31 +70,22 @@ importers:
         specifier: ^5.8.3
         version: 5.8.3
 
-  packages/tailwind-config:
-    devDependencies:
-      postcss-load-config:
-        specifier: '*'
-        version: 6.0.1(jiti@2.4.2)(postcss@8.5.3)(yaml@2.8.0)
-      tsdown:
-        specifier: ^0.12.3
-        version: 0.12.3(typescript@5.8.3)
-      typescript:
-        specifier: ^5.8.3
-        version: 5.8.3
-
   packages/ui:
     dependencies:
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       react:
         specifier: ^19.1.0
         version: 19.1.0
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
+      tailwind-merge:
+        specifier: ^3.3.0
+        version: 3.3.0
     devDependencies:
       '@tailwindcss/cli':
-        specifier: ^4.1.7
-        version: 4.1.7
-      '@tailwindcss/postcss':
         specifier: ^4.1.7
         version: 4.1.7
       '@tsconfig/vite-react':
@@ -109,12 +100,6 @@ importers:
       '@types/react-dom':
         specifier: ^19
         version: 19.1.5(@types/react@19.1.5)
-      postcss:
-        specifier: ^8
-        version: 8.5.3
-      postcss-load-config:
-        specifier: '*'
-        version: 6.0.1(jiti@2.4.2)(postcss@8.5.3)(yaml@2.8.0)
       tailwindcss:
         specifier: ^4.1.7
         version: 4.1.7
@@ -1379,6 +1364,10 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
@@ -2156,6 +2145,9 @@ packages:
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
+
+  tailwind-merge@3.3.0:
+    resolution: {integrity: sha512-fyW/pEfcQSiigd5SNn0nApUOxx0zB/dm6UDU/rEwc2c3sX2smWUNbapHv+QRqLGVp9GWX3THIa7MUGPo+YkDzQ==}
 
   tailwindcss@4.1.7:
     resolution: {integrity: sha512-kr1o/ErIdNhTz8uzAYL7TpaUuzKIE6QPQ4qmSdxnoX/lo+5wmUHQA6h3L5yIqEImSRnAAURDirLu/BgiXGPAhg==}
@@ -3626,6 +3618,8 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  clsx@2.1.1: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
@@ -4331,6 +4325,8 @@ snapshots:
       has-flag: 4.0.0
 
   supports-preserve-symlinks-flag@1.0.0: {}
+
+  tailwind-merge@3.3.0: {}
 
   tailwindcss@4.1.7: {}
 


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- TailwindCSS cn 클래스 유틸을 추가했습니다.
- `cn`을 사용해서 쉽게 여러 개의 `className`들을 이어 붙이면서도 중복되는 className은 자동으로 정리할 수 있습니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [ ] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **신규 기능**
	- Tailwind CSS 클래스 병합을 위한 유틸리티 함수가 추가되어, 컴포넌트에서 클래스명 결합이 더욱 간편해졌습니다.
- **리팩토링**
	- InterimButton, InterimDescription, InterimTitle 컴포넌트에서 클래스명 결합 방식을 개선하여, 일관성과 유지보수성이 향상되었습니다.
- **작업**
	- UI 패키지의 불필요한 PostCSS 관련 개발 의존성이 제거되고, 새로운 런타임 의존성이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->