### PR TITLE
[Y26W2-38] feat(root): pr label auto assign 개선

### DIFF
--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -66,7 +66,7 @@ jobs:
 
           for file in $CHANGED_FILES; do
             if [[ "$file" != packages/ui/* ]] && [[ "$file" != apps/web/* ]]; then
-              [[ "$file" == "pnpm-lock.json" ]] && continue
+              [[ "$file" == "pnpm-lock.yaml" ]] && continue
               ROOT_CHANGED=true
               break
             fi

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -66,7 +66,7 @@ jobs:
 
           for file in $CHANGED_FILES; do
             if [[ "$file" != packages/ui/* ]] && [[ "$file" != apps/web/* ]]; then
-              [[ "$file" == *.lock ]] && continue
+              [[ "$file" == "pnpm-lock.json" ]] && continue
               ROOT_CHANGED=true
               break
             fi

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -116,6 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write
+      issues: write
     steps:
       - name: Remove existing size labels
         uses: actions/github-script@v7

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -117,6 +117,31 @@ jobs:
     permissions:
       pull-requests: write
     steps:
+      - name: Remove existing size labels
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const prNumber = context.payload.pull_request.number;
+            const labels = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+            });
+
+            const sizeLabels = ['size/xs', 'size/s', 'size/m', 'size/l', 'size/xl'];
+            const labelsToRemove = labels.data
+              .map(label => label.name)
+              .filter(name => sizeLabels.includes(name));
+
+            for (const label of labelsToRemove) {
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                name: label,
+              });
+            }
       - uses: codelytv/pr-size-labeler@v1
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,7 +98,7 @@ importers:
         version: 4.1.7
       typescript:
         specifier: ^5.8.3
-        version: 5.8.3
+        version: 5.8.4
 
   packages/ui:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,7 +98,7 @@ importers:
         version: 4.1.7
       typescript:
         specifier: ^5.8.3
-        version: 5.8.4
+        version: 5.8.3
 
   packages/ui:
     dependencies:


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 스코프 설정에 대해 `pnpm-lock` 변경사항을 추적하지 않도록 수정했습니다!
- PR에 size 라벨이 중복으로 추가되는 문제를 방지하기 위해 기존 size 라벨을 먼저 제거하는 로직을 추가했습니다

## ✅ 체크리스트

- [x] 기능 동작 확인
- [ ] 코드 리뷰 반영
- [ ] 테스트 통과
- [ ] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - 루트 디렉토리 파일 변경 감지 시 "pnpm-lock.yaml"만 제외하도록 워크플로우를 개선했습니다.
  - PR에 기존 사이즈 라벨("size/xs", "size/s", "size/m", "size/l", "size/xl")이 있을 경우, 새로운 사이즈 라벨을 적용하기 전에 자동으로 제거하는 단계가 추가되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->