### PR TITLE
[Y26W2-51] feat(web): Pretendard 폰트 사용

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
   "editor.tabSize": 2,
+  "files.associations": {
+    "*.css": "tailwindcss"
+  },
   "tailwindCSS.classFunctions": ["clsx", "cn", "cva", "tw"],
   "tailwindCSS.experimental.classRegex": [
     ["clsx\\(.*?\\)(?!\\])", "(?:'|\"|`)([^\"'`]*)(?:'|\"|`)"],

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -19,6 +19,7 @@
     "@yapp-github/26th-web-team-2-fe-ui": "workspace:*",
     "jotai": "^2.12.5",
     "next": "^15.3.2",
+    "pretendard": "^1.3.9",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },

--- a/apps/web/src/app/app.css
+++ b/apps/web/src/app/app.css
@@ -1,6 +1,11 @@
 @import "tailwindcss";
 @import "@yapp-github/26th-web-team-2-fe-ui/app.css";
 
+@theme {
+  --font-sans: var(--font-pretendard), ui-sans-serif, system-ui, sans-serif,
+    "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol", "Noto Color Emoji";
+}
+
 :root {
   --background: #ffffff;
   --foreground: #171717;
@@ -16,5 +21,5 @@
 body {
   color: var(--foreground);
   background: var(--background);
-  font-family: Arial, Helvetica, sans-serif;
+  font-family: var(--font-sans);
 }

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,9 +1,15 @@
 import "./app.css";
 import type { Metadata } from "next";
-import { Geist } from "next/font/google";
+import localFont from "next/font/local";
 import Providers from "@/shared/providers";
 
-const geist = Geist({ subsets: ["latin"] });
+const Pretendard = localFont({
+  src: "../../node_modules/pretendard/dist/web/variable/woff2/PretendardVariable.woff2",
+  display: "swap",
+  weight: "45 920",
+  adjustFontFallback: false,
+  variable: "--font-pretendard",
+});
 
 export const metadata: Metadata = {
   title: "Create Turborepo",
@@ -17,7 +23,7 @@ export default function RootLayout({
 }) {
   return (
     <html lang="ko">
-      <body className={geist.className}>
+      <body className={Pretendard.variable}>
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/apps/web/turbo.json
+++ b/apps/web/turbo.json
@@ -7,6 +7,11 @@
       "dependsOn": ["@yapp-github/26th-web-team-2-fe-ui#build"],
       "with": ["test:watch"],
       "persistent": true
+    },
+    "test:watch": {
+      "cache": false,
+      "dependsOn": ["@yapp-github/26th-web-team-2-fe-ui#build"],
+      "persistent": true
     }
   }
 }

--- a/packages/ui/turbo.json
+++ b/packages/ui/turbo.json
@@ -14,6 +14,10 @@
     "dev:storybook": {
       "cache": false,
       "persistent": true
+    },
+    "test:watch": {
+      "cache": false,
+      "persistent": true
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       next:
         specifier: ^15.3.2
         version: 15.3.2(@babel/core@7.27.4)(@opentelemetry/api@1.9.0)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+      pretendard:
+        specifier: ^1.3.9
+        version: 1.3.9
       react:
         specifier: ^19.1.0
         version: 19.1.0
@@ -113,10 +116,10 @@ importers:
         version: 1.1.12(typescript@5.8.3)(webpack@5.99.9)
       postcss:
         specifier: ^8
-        version: 8.5.3
+        version: 8.5.6
       postcss-load-config:
         specifier: '*'
-        version: 6.0.1(jiti@2.4.2)(postcss@8.5.3)(yaml@2.8.0)
+        version: 6.0.1(jiti@2.4.2)(postcss@8.5.6)(yaml@2.8.0)
       tailwindcss:
         specifier: ^4.1.7
         version: 4.1.7
@@ -213,10 +216,10 @@ importers:
         version: 1.53.1
       postcss:
         specifier: ^8
-        version: 8.5.3
+        version: 8.5.6
       postcss-load-config:
         specifier: '*'
-        version: 6.0.1(jiti@2.4.2)(postcss@8.5.3)(yaml@2.8.0)
+        version: 6.0.1(jiti@2.4.2)(postcss@8.5.6)(yaml@2.8.0)
       storybook:
         specifier: ^9.0.6
         version: 9.0.12(@testing-library/dom@10.4.0)
@@ -4926,10 +4929,6 @@ packages:
     resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
     engines: {node: ^10 || ^12 || >=14}
 
-  postcss@8.5.3:
-    resolution: {integrity: sha512-dle9A3yYxlBSrt8Fu+IpjGT8SY8hN0mlaA6GY8t0P5PjIOZemULz/E2Bnm/2dcUOena75OTNkHI76uZBNUUq3A==}
-    engines: {node: ^10 || ^12 || >=14}
-
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
     engines: {node: ^10 || ^12 || >=14}
@@ -4961,6 +4960,9 @@ packages:
     resolution: {integrity: sha512-8Mf2cbV7x1cXPUILADGI3wuhfqWvtiLA1iclTDbFRZkgRQS0NqsPZphna9V+HyTEadheuPmjaJMsbzKQFOzLug==}
     engines: {node: '>=10'}
     hasBin: true
+
+  pretendard@1.3.9:
+    resolution: {integrity: sha512-PaQAADyLY5v4kYFwkpSJHbSSYIkiriY/1xXw75TKoZ9UQQqeU+tvP05yTdZAWibiIYoo8ZKtRv8PM7w0IaywSw==}
 
   pretty-format@27.5.1:
     resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
@@ -8528,7 +8530,7 @@ snapshots:
       '@alloc/quick-lru': 5.2.0
       '@tailwindcss/node': 4.1.7
       '@tailwindcss/oxide': 4.1.7
-      postcss: 8.5.3
+      postcss: 8.5.6
       tailwindcss: 4.1.7
 
   '@tanstack/query-core@5.80.7': {}
@@ -10863,21 +10865,15 @@ snapshots:
     optionalDependencies:
       fsevents: 2.3.2
 
-  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.3)(yaml@2.8.0):
+  postcss-load-config@6.0.1(jiti@2.4.2)(postcss@8.5.6)(yaml@2.8.0):
     dependencies:
       lilconfig: 3.1.3
     optionalDependencies:
       jiti: 2.4.2
-      postcss: 8.5.3
+      postcss: 8.5.6
       yaml: 2.8.0
 
   postcss@8.4.31:
-    dependencies:
-      nanoid: 3.3.11
-      picocolors: 1.1.1
-      source-map-js: 1.2.1
-
-  postcss@8.5.3:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -10921,6 +10917,8 @@ snapshots:
       simple-get: 4.0.1
       tar-fs: 2.1.3
       tunnel-agent: 0.6.0
+
+  pretendard@1.3.9: {}
 
   pretty-format@27.5.1:
     dependencies:
@@ -11844,7 +11842,7 @@ snapshots:
       esbuild: 0.25.5
       fdir: 6.4.4(picomatch@4.0.2)
       picomatch: 4.0.2
-      postcss: 8.5.3
+      postcss: 8.5.6
       rollup: 4.35.0
       tinyglobby: 0.2.14
     optionalDependencies:


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 주요 변경 사항
  - Pretendard 폰트 설정을 추가했습니다. `--font-sans`를 덮어 씌워서 기본 폰트로 전체 적용될 수 있도록 수정했습니다. (`@theme` 같은 css at-rules가 잘 인식될 수 있도록 함)
- 마이너 변경 사항
  - VSCode에서 `*.css` 파일은 `tailwindcss` 파일 타입으로 추정될 수 있도록 수정했습니다.
  - Turborepo에서 `test:watch` 커맨드가 병렬로 같이 실행되지 않아서 이를 수정했습니다. (`turbo.json` 파일)

## ✅ 체크리스트

- [x] 기능 동작 확인
- [ ] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
commit-id:a03955ad

---

**Stack**:
- #34
- #33
- #32 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 웹 및 UI 패키지에 테스트 워치(test:watch) 작업이 추가되어 테스트를 실시간으로 모니터링할 수 있습니다.

* **스타일**
  * 웹 앱의 기본 폰트가 Google Geist에서 Pretendard로 변경되었습니다.
  * Pretendard 폰트가 추가되고, 기본 폰트 패밀리 설정이 업데이트되었습니다.

* **환경 설정**
  * VSCode에서 모든 .css 파일이 Tailwind CSS로 인식되도록 설정이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->