### PR TITLE
[Y26W2-114] feat(root): Replace yapp-github, hul-zzuck with ssok

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,10 +1,10 @@
-name: 'Chromatic Auto Deploy on PR to Main'
+name: "Chromatic Auto Deploy on PR to Main"
 
 on:
   pull_request:
     types: [synchronize, labeled]
     branches:
-      - '**' 
+      - "**"
 
 permissions:
   contents: write
@@ -43,7 +43,7 @@ jobs:
             ${{ runner.os }}-pnpm-
 
       - name: Build Storybook for Design System
-        run: pnpm --filter @yapp-github/26th-web-team-2-fe-ui run build:storybook
+        run: pnpm --filter @ssok/ui run build:storybook
 
       - name: Publish to Chromatic
         id: chromatic

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -23,5 +23,3 @@ jobs:
           VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
           VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
           PRODUCTION: ${{ github.event_name == 'push' }}
-          BUILD_ENV: |
-            SENTRY_AUTH_TOKEN="${{ secrets.SENTRY_AUTH_TOKEN }}"

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# @yapp-github/26th-web-team-2-fe
+# ssock
 
 [![web](https://badgen.net/badge/web/26th-web-team-2-fe-web.vercel.app/blue?icon=vercel)](https://26th-web-team-2-fe-web.vercel.app/)
 [![docs](https://badgen.net/badge/docs/yapp-github.github.io/purple?icon=github)](https://yapp-github.github.io/26th-Web-Team-2-FE/)

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# ssock
+# ssok
 
 [![web](https://badgen.net/badge/web/26th-web-team-2-fe-web.vercel.app/blue?icon=vercel)](https://ssok-info.vercel.app/)
 [![docs](https://badgen.net/badge/docs/yapp-github.github.io/purple?icon=github)](https://yapp-github.github.io/26th-Web-Team-2-FE/)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # ssock
 
-[![web](https://badgen.net/badge/web/26th-web-team-2-fe-web.vercel.app/blue?icon=vercel)](https://26th-web-team-2-fe-web.vercel.app/)
+[![web](https://badgen.net/badge/web/26th-web-team-2-fe-web.vercel.app/blue?icon=vercel)](https://ssok-info.vercel.app/)
 [![docs](https://badgen.net/badge/docs/yapp-github.github.io/purple?icon=github)](https://yapp-github.github.io/26th-Web-Team-2-FE/)
 [![docs](https://badgen.net/badge/storybook/chromatic/pink?icon=https://cdn.jsdelivr.net/gh/storybookjs/brand@main/icon/icon-storybook-inverse.svg)](https://github.com/YAPP-Github/26th-Web-Team-2-FE/actions/workflows/chromatic.yml)

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@yapp-github/26th-web-team-2-fe-web",
+  "name": "@ssok/web",
   "version": "0.1.0",
   "private": true,
   "scripts": {
@@ -14,9 +14,9 @@
   },
   "dependencies": {
     "@sentry/nextjs": "^9.25.1",
+    "@ssok/ui": "workspace:*",
     "@tanstack/react-query": "^5.80.6",
     "@tanstack/react-query-devtools": "^5.80.6",
-    "@yapp-github/26th-web-team-2-fe-ui": "workspace:*",
     "jotai": "^2.12.5",
     "next": "^15.3.2",
     "pretendard": "^1.3.9",

--- a/apps/web/src/app/app.css
+++ b/apps/web/src/app/app.css
@@ -1,5 +1,5 @@
 @import "tailwindcss";
-@import "@yapp-github/26th-web-team-2-fe-ui/app.css";
+@import "@ssok/ui/app.css";
 
 :root {
   --background: #ffffff;

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,10 +1,6 @@
 "use client";
 
-import {
-  InterimButton,
-  InterimDescription,
-  InterimTitle,
-} from "@yapp-github/26th-web-team-2-fe-ui";
+import { InterimButton, InterimDescription, InterimTitle } from "@ssok/ui";
 import { useAtom } from "jotai";
 import IcCheckBlack from "@/shared/assets/svg/ic_check_black_22.svg";
 import { counterAtom } from "@/shared/atoms/counter";

--- a/apps/web/turbo.json
+++ b/apps/web/turbo.json
@@ -4,13 +4,13 @@
   "tasks": {
     "dev": {
       "cache": false,
-      "dependsOn": ["@yapp-github/26th-web-team-2-fe-ui#build"],
+      "dependsOn": ["@ssok/ui#build"],
       "with": ["test:watch"],
       "persistent": true
     },
     "test:watch": {
       "cache": false,
-      "dependsOn": ["@yapp-github/26th-web-team-2-fe-ui#build"],
+      "dependsOn": ["@ssok/ui#build"],
       "persistent": true
     }
   }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -2,7 +2,7 @@ import { defineConfig } from "vitepress";
 
 export default defineConfig({
   base: "/26th-Web-Team-2-FE/",
-  title: "Trip with Hul-zzuk",
+  title: "Trip with Ssok",
   description: "YAPP 26th WEB 2 Team",
   themeConfig: {
     nav: [{ text: "Home", link: "/" }],

--- a/docs/index.md
+++ b/docs/index.md
@@ -3,7 +3,7 @@
 layout: home
 
 hero:
-  name: "Trip with Hul-zzuk ✈️"
+  name: "Trip with Ssok ✈️"
   text: "YAPP 26th WEB 2"
   tagline: 프로젝트 진행을 위한 컨벤션에 대한 내용을 담고 있습니다
   actions:

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@yapp-github/26th-web-team-2-fe-docs",
+  "name": "@ssok/docs",
   "version": "0.1.0",
   "private": true,
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
-  "name": "@yapp-github/26th-web-team-2-fe",
+  "name": "@ssok/root",
   "private": true,
   "scripts": {
     "build": "turbo run build",
-    "build:storybook": "pnpm --filter @yapp-github/26th-web-team-2-fe-ui run build:storybook",
+    "build:storybook": "pnpm --filter @ssok/ui run build:storybook",
     "check-types": "turbo run check-types",
     "commit": "git-cz",
     "dev": "turbo run dev",

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@yapp-github/26th-web-team-2-fe-ui",
+  "name": "@ssok/ui",
   "version": "0.1.0",
   "private": true,
   "exports": {

--- a/packages/ui/src/introduction.mdx
+++ b/packages/ui/src/introduction.mdx
@@ -2,9 +2,9 @@ import { Meta, Primary, Controls, Story } from '@storybook/blocks';
 
 <Meta title="Introduction" />
 
-# ✈️ Hulzzuck Design System (HDS)
+# ✈️ Ssok Design System (SDS)
 
-### The Design System for Hulzzuck
+### The Design System for Ssok
 
 <br />
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,7 +56,7 @@ importers:
       '@tanstack/react-query-devtools':
         specifier: ^5.80.6
         version: 5.81.5(@tanstack/react-query@5.81.5(react@19.1.0))(react@19.1.0)
-      '@yapp-github/26th-web-team-2-fe-ui':
+      '@ssok/ui':
         specifier: workspace:*
         version: link:../../packages/ui
       jotai:


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 프로젝트 이름이 결정되어서 기존에 사용하던 `yapp-github`, `hul-zzuck` 등 키워드를 `ssok`로 변경했습니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 프로젝트 및 패키지 명칭이 "@yapp-github/26th-web-team-2-fe"에서 "@ssok"으로 변경되었습니다.
  * 디자인 시스템 및 문서, UI 컴포넌트, 웹 앱 등 전체적으로 명칭이 "Hul-zzuk"에서 "Ssok"으로 일괄 변경되었습니다.

* **Documentation**
  * 문서 및 소개 페이지, Vitepress 설정에서 프로젝트 및 디자인 시스템 이름이 "Ssok"으로 업데이트되었습니다.

* **Chores**
  * 의존성 및 워크플로우, 빌드 스크립트 등에서 패키지 이름이 "@ssok" 계열로 수정되었습니다.
  * 배포 워크플로우에서 Sentry 인증 토큰 관련 환경 변수 설정이 제거되었습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->