### PR TITLE
[Y26W2-116] feat(ui): TextField 컴포넌트 개선

### DIFF
--- a/packages/ui/src/text-field/index.stories.tsx
+++ b/packages/ui/src/text-field/index.stories.tsx
@@ -3,7 +3,7 @@ import IcAlert from "@/assets/icons/ic_alert.svg?react";
 import IcLink from "@/assets/icons/ic_link.svg?react";
 import { TextField, type TextFieldProps } from "@/text-field";
 
-export default {
+const meta: Meta<TextFieldProps> = {
   title: "Components/TextField",
   component: TextField,
   parameters: {
@@ -27,13 +27,16 @@ export default {
       control: "text",
     },
   },
-} as Meta<TextFieldProps>;
+  decorators: [
+    (Story) => (
+      <div className="mx-auto w-full max-w-[35.9rem]">
+        <Story />
+      </div>
+    ),
+  ],
+};
 
-const Template: StoryFn<TextFieldProps> = (args) => (
-  <div className="mx-auto w-full max-w-[35.9rem]">
-    <TextField {...args} />
-  </div>
-);
+const Template: StoryFn<TextFieldProps> = (args) => <TextField {...args} />;
 
 export const Default: StoryFn<TextFieldProps> = Template.bind({});
 Default.args = {
@@ -47,3 +50,5 @@ WithError.args = {
   endIcon: <IcAlert width={24} height={24} />,
   hasError: true,
 };
+
+export default meta;

--- a/packages/ui/src/text-field/index.tsx
+++ b/packages/ui/src/text-field/index.tsx
@@ -14,15 +14,9 @@ export interface TextFieldProps
 
 const variants = cva(
   [
-    "flex",
-    "relative",
-    "items-center",
-    "w-full",
-    "rounded-[1.2rem]",
-    "border",
-    "outline-none",
-    "transition-all",
-    "duration-200",
+    "relative flex w-full items-center rounded-[1.2rem] border outline-none",
+    "text-body1-regular16 text-neutral-20",
+    "transition-all duration-200",
   ],
   {
     variants: {
@@ -85,7 +79,7 @@ export const TextField = ({
         className={cn(
           "w-full px-[1.6rem] py-[1.2rem]",
           "border-none bg-transparent outline-none",
-          "text-body1-regular16 text-neutral-20 placeholder:text-neutral-70",
+          "text-inherit placeholder:text-neutral-70",
           "transition-all duration-200",
           icon && !hasValue && "indent-[3.2rem]",
           endIcon && "pr-[4.8rem]",


### PR DESCRIPTION
## ✨ 변경 사항

- Storybook의 Template 내에서 div를 씌우는 대신, meta의 decorator를 이용하도록 수정했습니다.
- input value에 사용되는 text 색상을 `input` 컴포넌트에 직접 적용하는 대신, 상위 컨테이너에 정의하고 `input`에서는 `text-inherit`으로 따라가도록 설정했습니다. (https://github.com/YAPP-Github/26th-Web-Team-2-FE/pull/47 에서 text 색상을 바로 지정하기 위함)

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
commit-id:c2ebf220

---

**Stack**:
- #49
- #47
- #46 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * TextField 컴포넌트의 스타일 클래스가 정리되고 텍스트 스타일이 컨테이너에 적용되어 일관성이 향상되었습니다.
  * Storybook에서 모든 TextField 스토리가 중앙 정렬 및 최대 너비로 감싸지도록 데코레이터가 추가되었습니다.

* **Refactor**
  * Storybook 스토리 정의 방식이 개선되어 코드가 더 간결해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->