### PR TITLE
[Y26W2-60] feat(web): google map 연동 및 pin 커스텀 설정

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,6 +18,8 @@
     "@ssok/ui": "workspace:*",
     "@tanstack/react-query": "^5.80.6",
     "@tanstack/react-query-devtools": "^5.80.6",
+    "@types/google-map-react": "^2.1.10",
+    "google-map-react": "^2.2.5",
     "jotai": "^2.12.5",
     "next": "^15.3.2",
     "pretendard": "^1.3.9",

--- a/apps/web/src/app/boards/[id]/layout.tsx
+++ b/apps/web/src/app/boards/[id]/layout.tsx
@@ -1,4 +1,5 @@
 import type { PropsWithChildren } from "react";
+import MapComponent from "@/shared/components/Map";
 import SideNavigation from "@/shared/components/SideNavigation";
 
 const BoardsIdLayout = ({ children }: PropsWithChildren) => {
@@ -6,6 +7,7 @@ const BoardsIdLayout = ({ children }: PropsWithChildren) => {
     <div className="flex h-screen">
       <SideNavigation />
       {children}
+      <MapComponent />
     </div>
   );
 };

--- a/apps/web/src/shared/components/Map/MapPin.tsx
+++ b/apps/web/src/shared/components/Map/MapPin.tsx
@@ -1,0 +1,18 @@
+import { Pin } from "@ssok/ui";
+
+type PinProps = {
+  className?: string;
+  children: React.ReactNode;
+  lat: number;
+  lng: number;
+};
+
+const MapPin = ({ className, children, lat, lng }: PinProps) => {
+  return (
+    <div data-lat={lat} data-lng={lng}>
+      <Pin className={className}>{children}</Pin>
+    </div>
+  );
+};
+
+export default MapPin;

--- a/apps/web/src/shared/components/Map/index.tsx
+++ b/apps/web/src/shared/components/Map/index.tsx
@@ -1,0 +1,45 @@
+"use client";
+
+import GoogleMapReact from "google-map-react";
+import { calculateCenter } from "@/shared/utils/map-utils";
+import MapPin from "./MapPin";
+
+// TODO: mock 데이터 삭제 후 실제 데이터로 교체
+const locMock = [
+  { id: 1, latitude: 37.5665, longitude: 126.978, label: "서울 시청이야!" },
+  { id: 2, latitude: 37.3943, longitude: 126.9568, label: "여긴 안양이야!" },
+  { id: 3, latitude: 37.3219, longitude: 127.1265, label: "성남 어쩌구 숙소" },
+  {
+    id: 4,
+    latitude: 37.5407,
+    longitude: 127.0796,
+    label: "광진구 저쩌구 숙소",
+  },
+  { id: 5, latitude: 37.4563, longitude: 126.7052, label: "인천 어쩌구 숙소" },
+];
+
+const MapComponent = () => {
+  return (
+    <div className=" h-screen w-full">
+      <GoogleMapReact
+        bootstrapURLKeys={{
+          key: process.env.NEXT_PUBLIC_GOOGLE_MAP_API_KEY,
+        }}
+        defaultCenter={calculateCenter(locMock)}
+        defaultZoom={11}
+      >
+        {locMock.map((location) => (
+          <MapPin
+            key={location.id}
+            lat={location.latitude}
+            lng={location.longitude}
+          >
+            {location.label}
+          </MapPin>
+        ))}
+      </GoogleMapReact>
+    </div>
+  );
+};
+
+export default MapComponent;

--- a/apps/web/src/shared/utils/map-utils.ts
+++ b/apps/web/src/shared/utils/map-utils.ts
@@ -1,0 +1,32 @@
+/**
+ * 여러 위치들의 중심 좌표를 계산하는 함수입니다.
+ *
+ * @param locations - 각각의 위치를 나타내는 객체 배열입니다.
+ *   - id: 고유한 위치 식별자
+ *   - latitude: 위도 (y좌표)
+ *   - longitude: 경도 (x좌표)
+ *
+ * @returns lat와 lng를 포함한 객체로,
+ *   주어진 위치들의 평균 위도와 평균 경도를 중심 좌표로 반환합니다.
+ *   {
+ *     lat: number,  // 평균 위도
+ *     lng: number   // 평균 경도
+ *   }
+ *
+ * @description
+ * 이 함수는 locations가 비어있을 경우, 기본값으로 서울 시청의 좌표를 반환합니다.
+ *
+ */
+export const calculateCenter = (
+  locations: { id: number; latitude: number; longitude: number }[],
+) => {
+  if (locations.length === 0) {
+    return { lat: 37.5665, lng: 126.978 };
+  }
+
+  const lat =
+    locations.reduce((acc, loc) => acc + loc.latitude, 0) / locations.length;
+  const lng =
+    locations.reduce((acc, loc) => acc + loc.longitude, 0) / locations.length;
+  return { lat, lng };
+};

--- a/apps/web/src/types/env.d.ts
+++ b/apps/web/src/types/env.d.ts
@@ -1,0 +1,9 @@
+declare global {
+  namespace NodeJS {
+    interface ProcessEnv {
+      NEXT_PUBLIC_GOOGLE_MAP_API_KEY: string;
+    }
+  }
+}
+
+export {};

--- a/apps/web/tests/map-utils.test.ts
+++ b/apps/web/tests/map-utils.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from "vitest";
+import { calculateCenter } from "@/shared/utils/map-utils";
+
+describe("calculateCenter", () => {
+  // 여러 좌표가 있을 때 평균 좌표를 반환
+  it("should return average of multiple coordinates", () => {
+    const locations = [
+      { id: 1, latitude: 10, longitude: 10 },
+      { id: 2, latitude: 20, longitude: 20 },
+      { id: 3, latitude: 30, longitude: 30 },
+    ];
+
+    const center = calculateCenter(locations);
+
+    expect(center.lat).toBeCloseTo(20);
+    expect(center.lng).toBeCloseTo(20);
+  });
+
+  // 좌표가 하나만 있을 때는 그 좌표 자체를 반환
+  it("should return the coordinate itself when only one exists", () => {
+    const locations = [{ id: 1, latitude: 37.5, longitude: 126.9 }];
+
+    const center = calculateCenter(locations);
+
+    expect(center.lat).toBeCloseTo(37.5);
+    expect(center.lng).toBeCloseTo(126.9);
+  });
+
+  // 빈 배열일 때는 서울 시청 좌표를 기본값으로 반환
+  it("should return default location for empty location array", () => {
+    const locations: { id: number; latitude: number; longitude: number }[] = [];
+
+    const center = calculateCenter(locations);
+
+    expect(center.lat).toBeCloseTo(37.5665);
+    expect(center.lng).toBeCloseTo(126.978);
+  });
+});

--- a/packages/ui/src/components/pin/index.tsx
+++ b/packages/ui/src/components/pin/index.tsx
@@ -10,7 +10,7 @@ export const Pin = ({ children, className, ...props }: PinProps) => {
     <button
       className={cn(
         // 본체 스타일
-        "relative inline-flex items-center justify-center text-heading2-semi18 text-primary-5 shadow-[2px_4px_6px_0px_rgba(0,0,0,0.2)]",
+        "relative inline-flex w-max items-center justify-center text-heading2-semi18 text-primary-5 shadow-[2px_4px_6px_0px_rgba(0,0,0,0.2)]",
         "rounded-[4.8rem] border border-neutral-70 bg-neutral-100 px-[1.6rem] py-[0.8rem]",
         "hover:border-neutral-60 focus:border-primary-5",
         "focus:bg-primary-5 focus:text-primary-100",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -62,6 +62,12 @@ importers:
       '@tanstack/react-query-devtools':
         specifier: ^5.80.6
         version: 5.81.5(@tanstack/react-query@5.81.5(react@19.1.0))(react@19.1.0)
+      '@types/google-map-react':
+        specifier: ^2.1.10
+        version: 2.1.10
+      google-map-react:
+        specifier: ^2.2.5
+        version: 2.2.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
       jotai:
         specifier: ^2.12.5
         version: 2.12.5(@types/react@19.1.8)(react@19.1.0)
@@ -1478,6 +1484,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@googlemaps/js-api-loader@1.16.10':
+    resolution: {integrity: sha512-c2erv2k7P2ilYzMmtYcMgAR21AULosQuUHJbStnrvRk2dG93k5cqptDrh9A8p+ZNlyhiqEOgHW7N9PAizdUM7Q==}
+
   '@iconify-json/simple-icons@1.2.42':
     resolution: {integrity: sha512-G/EED0hUV1wMNUsWaFdQYLibm6SO7rP2GZP1+CvhszB5WAFYYibD3zoWp3X96xSIWpYQFvccvE17ewpd0Q1hWQ==}
 
@@ -1753,6 +1762,9 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.29':
     resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
+
+  '@mapbox/point-geometry@0.1.0':
+    resolution: {integrity: sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==}
 
   '@mdx-js/react@3.1.0':
     resolution: {integrity: sha512-QjHtSaoameoalGnKDT3FoIl4+9RwyTmo9ZJGBdLOks/YOiWHoRDI3PUwEzOE7kEmGcV3AFcp9K6dYu9rEuKLAQ==}
@@ -2882,6 +2894,9 @@ packages:
 
   '@types/file-loader@5.0.4':
     resolution: {integrity: sha512-aB4X92oi5D2nIGI8/kolnJ47btRM2MQjQS4eJgA/VnCD12x0+kP5v7b5beVQWKHLOcquwUXvv6aMt8PmMy9uug==}
+
+  '@types/google-map-react@2.1.10':
+    resolution: {integrity: sha512-8/0UllZS7tF08WNBRPQlSJCkETvz3e3sZoPxzDaWkj2iV5dmFSnOKXVtoeKo8dLZSe+RkLn479t1wj6nXmLLSA==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -4041,6 +4056,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
@@ -4267,6 +4285,13 @@ packages:
 
   globrex@0.1.2:
     resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
+
+  google-map-react@2.2.5:
+    resolution: {integrity: sha512-6n4pb4Ckmt3TnvJ5fNPSu2kceIItMrJR413YfX89tNq95nTipFwxL2lmeR+IHFl1cXzKpFvQ4leXzJza0LlapA==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
@@ -4757,6 +4782,10 @@ packages:
   longest@2.0.1:
     resolution: {integrity: sha512-Ajzxb8CM6WAnFjgiloPsI3bF+WCxcvhdIG3KNA2KN962+tdBsHcuQ4k4qX/EcS/2CRkcc0iAkR956Nib6aXU/Q==}
     engines: {node: '>=0.10.0'}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
 
   loupe@3.1.4:
     resolution: {integrity: sha512-wJzkKwJrheKtknCOKNEtDK4iqg/MxmZheEMtSTYvnzRdEYaZzmgH976nenp8WdJRdx5Vc1X/9MO0Oszl6ezeXg==}
@@ -5346,6 +5375,9 @@ packages:
   prompts@2.4.2:
     resolution: {integrity: sha512-NxNv/kLguCA7p3jE8oL2aEBsrJWgAakBpgmgK6lpPWV+WuOmY6r2/zbAVnP+T8bQlA0nzHXSJSJW0Hq7ylaD2Q==}
     engines: {node: '>= 6'}
+
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
 
   property-information@7.1.0:
     resolution: {integrity: sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==}
@@ -7727,6 +7759,8 @@ snapshots:
   '@esbuild/win32-x64@0.25.6':
     optional: true
 
+  '@googlemaps/js-api-loader@1.16.10': {}
+
   '@iconify-json/simple-icons@1.2.42':
     dependencies:
       '@iconify/types': 2.0.0
@@ -7939,6 +7973,8 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.4
+
+  '@mapbox/point-geometry@0.1.0': {}
 
   '@mdx-js/react@3.1.0(@types/react@19.1.8)(react@19.1.0)':
     dependencies:
@@ -9145,6 +9181,10 @@ snapshots:
   '@types/file-loader@5.0.4':
     dependencies:
       '@types/webpack': 4.41.40
+
+  '@types/google-map-react@2.1.10':
+    dependencies:
+      '@types/react': 19.1.8
 
   '@types/hast@3.0.4':
     dependencies:
@@ -10398,6 +10438,8 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@4.0.7: {}
+
   eventemitter3@5.0.1: {}
 
   events@3.3.0: {}
@@ -10641,6 +10683,15 @@ snapshots:
       unicorn-magic: 0.3.0
 
   globrex@0.1.2: {}
+
+  google-map-react@2.2.5(react-dom@19.1.0(react@19.1.0))(react@19.1.0):
+    dependencies:
+      '@googlemaps/js-api-loader': 1.16.10
+      '@mapbox/point-geometry': 0.1.0
+      eventemitter3: 4.0.7
+      prop-types: 15.8.1
+      react: 19.1.0
+      react-dom: 19.1.0(react@19.1.0)
 
   gopd@1.2.0: {}
 
@@ -11114,6 +11165,10 @@ snapshots:
       wrap-ansi: 9.0.0
 
   longest@2.0.1: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
 
   loupe@3.1.4: {}
 
@@ -11715,6 +11770,12 @@ snapshots:
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
+
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
 
   property-information@7.1.0: {}
 


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- `Google Map`을 연결하여 `Layout`에 렌더링했습니다.
- `Layout` 쪽 서버 사이드 렌더링 컴포넌트를 유지하기 위해, 별도로 `shared` 폴더에 `Map` 컴포넌트를 분리해두었습니다. (API 키는 노션에 남겨두었으니, Vercel 환경변수에도 추가 부탁드립니다! 🙌)
- 테스트를 위해 Swagger 데이터 형식에 맞춰 mock 데이터로 lat과 lng 값을 임의로 지정했습니다.
- `Google Map`의 `defaultCenter` 값은 숙소 위치들의 평균 좌표를 계산하는 유틸 함수로 구하도록 구현했고, 해당 함수에 대한 Vitest 테스트 코드도 작성했습니다.



## ✅ 체크리스트

- [ ] 기능 동작 확인
- [ ] 코드 리뷰 반영
- [ ] 테스트 통과
- [ ] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->
<img width="3402" height="1756" alt="image" src="https://github.com/user-attachments/assets/bb3388e9-96e3-403e-9d34-652088491c9e" />


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
commit-id:0e700638

[Y26W2-60] test(web): map util calculateCenter 테스트 코드 작성

commit-id:119b1e1a

[Y26W2-60] fix(web): build type error resolve

commit-id:a9db8228

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


* **신규 기능**
  * Google Maps가 통합된 새로운 지도 컴포넌트가 추가되었습니다.
  * 지도에 여러 위치를 핀으로 표시하는 기능이 제공됩니다.
  * 지도 중심 좌표를 계산하는 기능이 추가되었습니다.

* **버그 수정**
  * 핀 컴포넌트의 버튼이 내용에 맞게 너비가 자동 조정되도록 개선되었습니다.

* **테스트**
  * 지도 중심 좌표 계산 유틸리티 함수에 대한 테스트가 추가되었습니다.

* **Chores**
  * Google Maps 관련 라이브러리 및 타입 패키지가 프로젝트에 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->