### PR TITLE
[Y26W2-126] feat(web): 비교표 이미지가 정상적으로 보여지도록 수정

### DIFF
--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -27,5 +27,11 @@ const plugins = [
 ];
 
 export default plugins.reduce((acc, plugin) => plugin(acc), {
+  images: {
+    remotePatterns: [
+      { protocol: "http", hostname: "*" },
+      { protocol: "https", hostname: "*" },
+    ],
+  },
   reactStrictMode: true,
 } as NextConfig);

--- a/apps/web/src/domains/compare/components/compare-table/photo-cell.tsx
+++ b/apps/web/src/domains/compare/components/compare-table/photo-cell.tsx
@@ -1,4 +1,5 @@
 import { IcInfo } from "@ssok/ui";
+import Image from "next/image";
 
 interface PhotoCellProps {
   images?: string[];
@@ -13,11 +14,22 @@ const PhotoCell = ({ images, name, price }: PhotoCellProps) => {
 
   return (
     <section className="w-full">
-      <div className="mb-[1.6rem] flex h-[24.4rem] w-full items-center justify-center rounded-[1.2rem] bg-neutral-90">
-        <span className="text-body2-regular14 text-neutral-40">
-          {images?.[0] || "이미지 없음"}
-        </span>
-      </div>
+      {images?.[0] && (
+        <Image
+          src={images[0]}
+          alt="숙소 이미지"
+          width={100}
+          height={100}
+          className="mb-[1.6rem] h-[24.4rem] w-full rounded-[1.2rem]"
+        />
+      )}
+      {!images?.[0] && (
+        <div className="mb-[1.6rem] flex h-[24.4rem] w-full items-center justify-center rounded-[1.2rem] bg-neutral-90">
+          <span className="text-body2-regular14 text-neutral-40">
+            {"이미지 없음"}
+          </span>
+        </div>
+      )}
 
       <div>
         <p className="mb-[0.8rem] text-neutral-30 text-title3-semi24">

--- a/apps/web/src/domains/compare/hooks/use-compare-data.ts
+++ b/apps/web/src/domains/compare/hooks/use-compare-data.ts
@@ -5,7 +5,9 @@ const mockCompareData: Accommodation[] = [
     id: 1,
     accommodationName: "파크 하이엇 도쿄",
     lowestPrice: 250000,
-    images: ["photo1.jpg"],
+    images: [
+      "https://pix8.agoda.net/hotelImages/9373867/0/d325a6b849fb3bcce909f813ea7adfb8.jpg?ce=2&s=1024x",
+    ],
     reviewScore: 8.5,
     cleanlinessScore: 7.2,
     nearbyAttractions: [
@@ -81,7 +83,9 @@ const mockCompareData: Accommodation[] = [
     id: 2,
     accommodationName: "아사쿠사 류칸",
     lowestPrice: 180000,
-    images: ["photo5.jpg"],
+    images: [
+      "https://pix8.agoda.net/hotelImages/49986351/0/e311c6d8b735a44ace73b8219d07876d.jpeg?ce=0&s=600x",
+    ],
     reviewScore: 7.8,
     cleanlinessScore: 8.9,
     nearbyAttractions: [
@@ -154,7 +158,9 @@ const mockCompareData: Accommodation[] = [
     id: 3,
     accommodationName: "만다린 오리엔탈 도쿄",
     lowestPrice: 450000,
-    images: ["photo9.jpg"],
+    images: [
+      "https://pix8.agoda.net/hotelImages/692/69287/69287_16060314210043106872.jpg?ca=6&ce=1&s=600x",
+    ],
     reviewScore: 9.2,
     cleanlinessScore: 9.5,
     nearbyAttractions: [
@@ -237,7 +243,9 @@ const mockCompareData: Accommodation[] = [
     id: 4,
     accommodationName: "도쿄 비즈니스 호텔",
     lowestPrice: 120000,
-    images: ["photo13.jpg"],
+    images: [
+      "https://pix8.agoda.net/hotelImages/1723671/-1/47378d14e9f58fdd96ed6f18b4f8f060.jpg?ca=13&ce=1&s=1024x",
+    ],
     reviewScore: 6.8,
     cleanlinessScore: 6.5,
     nearbyAttractions: [


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 비교표 이미지가 임시 데이터로 보여질 수 있도록 수정하는 간단한 변경 사항입니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

<img width="3600" height="2064" alt="CleanShot 2025-07-26 at 19 37 25@2x" src="https://github.com/user-attachments/assets/babb987a-761d-4387-98d6-a0e1d7e24aea" />

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->
