### PR TITLE
[Y26W2-214] feat(app): maze-us 연동 추가

### DIFF
--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import "./app.css";
 import type { Metadata } from "next";
 import localFont from "next/font/local";
+import MazeUs from "@/shared/components/maze-us";
 import Providers from "@/shared/providers";
 
 const Pretendard = localFont({
@@ -22,6 +23,7 @@ const RootLayout = ({ children }: { children: React.ReactNode }) => {
       <body className={Pretendard.variable}>
         <Providers>{children}</Providers>
       </body>
+      <MazeUs />
     </html>
   );
 };

--- a/apps/web/src/shared/components/maze-us/index.tsx
+++ b/apps/web/src/shared/components/maze-us/index.tsx
@@ -1,0 +1,29 @@
+import Script from "next/script";
+
+const MazeUs = () => {
+  return (
+    <Script id="maze-us" strategy="beforeInteractive">
+      {`(function (m, a, z, e) {
+          var s, t;
+          try {
+            t = m.sessionStorage.getItem('maze-us');
+          } catch (err) {}
+
+          if (!t) {
+            t = Date.now();
+            try {
+              m.sessionStorage.setItem('maze-us', t);
+            } catch (err) {}
+          }
+
+          s = a.createElement('script');
+          s.src = z + '?apiKey=' + e;
+          s.async = true;
+          a.getElementsByTagName('head')[0].appendChild(s);
+          m.mazeUniversalSnippetApiKey = e;
+        })(window, document, 'https://snippet.maze.co/maze-universal-loader.js', '391259ac-78a9-4e9c-a970-06317d6fc17e');`}
+    </Script>
+  );
+};
+
+export default MazeUs;


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- Maze에서 웹 사이트 연동 및 테스트를 진행할 수 있도록 커스텀 스크립트를 추가했습니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

<img width="535" height="825" alt="CleanShot 2025-07-31 at 22 59 15@2x" src="https://github.com/user-attachments/assets/de01701e-44f9-4336-853b-3cc1634625eb" />


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 외부 서비스(Maze) 연동을 위한 스크립트가 모든 페이지에 추가되었습니다.  
  * 사용자 경험 분석을 위한 MazeUs 컴포넌트가 도입되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->