### PR TITLE
[Y26W2-126] feat(web): AddCell 내용 보충하기 버튼 추가

### DIFF
--- a/apps/web/src/domains/compare/components/compare-table/add-cell.tsx
+++ b/apps/web/src/domains/compare/components/compare-table/add-cell.tsx
@@ -1,0 +1,27 @@
+import { cn, IcAddBox, IcInfo } from "@ssok/ui";
+
+interface AddCellProps {
+  onClick?: () => void;
+  className?: string;
+}
+
+const AddCell = ({ onClick, className }: AddCellProps) => {
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={cn(
+        "mb-[1.6rem] flex h-full w-full cursor-pointer items-center justify-center rounded-[1.2rem] border-2 border-neutral-90 border-dashed bg-neutral-99 transition-colors hover:border-neutral-90 hover:bg-neutral-95",
+        className,
+      )}
+    >
+      <IcAddBox width="24" height="24" className="mr-[1rem] text-neutral-70" />
+      <span className="mr-[0.2rem] text-body1-semi16 text-neutral-60">
+        내용 보충하기
+      </span>
+      <IcInfo width="20" height="20" className="text-neutral-70" />
+    </button>
+  );
+};
+
+export default AddCell;

--- a/apps/web/src/domains/compare/components/compare-table/amenities-cell.tsx
+++ b/apps/web/src/domains/compare/components/compare-table/amenities-cell.tsx
@@ -16,12 +16,12 @@ import TableAmenitiesContents from "@/domains/compare/components/table-amenities
 import type { Accommodation } from "@/domains/compare/types";
 
 interface AmenitiesCellProps {
-  amenities: Accommodation["amenities"];
+  amenities: NonNullable<Accommodation["amenities"]>;
 }
 
 const AmenitiesCell = ({ amenities }: AmenitiesCellProps) => {
   const available = amenities
-    ?.filter((amenity) => amenity.available && amenity.type)
+    .filter((amenity) => amenity.available && amenity.type)
     .map((amenity) => ({
       text: amenity.type || "",
       label: amenity.description || "",

--- a/apps/web/src/domains/compare/components/compare-table/cleanliness-score-cell.tsx
+++ b/apps/web/src/domains/compare/components/compare-table/cleanliness-score-cell.tsx
@@ -1,7 +1,7 @@
 import { Graph } from "@ssok/ui";
 
 interface CleanlinessScoreCellProps {
-  score?: number;
+  score: number;
 }
 
 const CleanlinessScoreCell = ({ score }: CleanlinessScoreCellProps) => {
@@ -13,9 +13,7 @@ const CleanlinessScoreCell = ({ score }: CleanlinessScoreCellProps) => {
     return "매우 나쁨";
   };
 
-  const safeScore = score || 0;
-
-  return <Graph value={safeScore} label={getLabel(safeScore)} showGraph />;
+  return <Graph value={score} label={getLabel(score)} showGraph />;
 };
 
 export default CleanlinessScoreCell;

--- a/apps/web/src/domains/compare/components/compare-table/index.tsx
+++ b/apps/web/src/domains/compare/components/compare-table/index.tsx
@@ -2,6 +2,7 @@
 
 import { cn } from "@ssok/ui";
 import { Fragment } from "react";
+import AddCell from "@/domains/compare/components/compare-table/add-cell";
 import AmenitiesCell from "@/domains/compare/components/compare-table/amenities-cell";
 import CheckInOutCell from "@/domains/compare/components/compare-table/check-in-out-cell";
 import CleanlinessScoreCell from "@/domains/compare/components/compare-table/cleanliness-score-cell";
@@ -30,6 +31,19 @@ const CompareTable = ({ items, className }: CompareTableProps) => {
     { key: "reviewSummary", label: "리뷰 요약" },
   ];
 
+  const getGridCols = (itemCount: number) => {
+    switch (itemCount) {
+      case 1:
+        return "grid-cols-1";
+      case 2:
+        return "grid-cols-2";
+      case 3:
+        return "grid-cols-3";
+      default:
+        return "grid-cols-4";
+    }
+  };
+
   const renderCellContent = (item: Accommodation, rowKey: string) => {
     switch (rowKey) {
       case "photo":
@@ -43,14 +57,29 @@ const CompareTable = ({ items, className }: CompareTableProps) => {
           />
         );
       case "reviewScore":
+        if (!item.reviewScore) {
+          return <AddCell />;
+        }
         return <ReviewScoreCell score={item.reviewScore} />;
       case "cleanlinessScore":
+        if (!item.cleanlinessScore) {
+          return <AddCell />;
+        }
         return <CleanlinessScoreCell score={item.cleanlinessScore} />;
       case "nearbyAttractions":
+        if (!item.nearbyAttractions) {
+          return <AddCell />;
+        }
         return <NearbyAttractionsCell attractions={item.nearbyAttractions} />;
       case "amenities":
+        if (!item.amenities) {
+          return <AddCell />;
+        }
         return <AmenitiesCell amenities={item.amenities} />;
       case "nearbyTransportation":
+        if (!item.nearbyTransportation) {
+          return <AddCell />;
+        }
         return (
           <NearbyTransportationCell
             transportation={item.nearbyTransportation}
@@ -59,7 +88,7 @@ const CompareTable = ({ items, className }: CompareTableProps) => {
       case "checkInOut": {
         const { checkInTime, checkOutTime } = item;
         if (!isCheckTimeExist(checkInTime) || !isCheckTimeExist(checkOutTime)) {
-          return null;
+          return <AddCell />;
         }
 
         return (
@@ -70,6 +99,9 @@ const CompareTable = ({ items, className }: CompareTableProps) => {
         );
       }
       case "reviewSummary":
+        if (!item.reviewSummary) {
+          return <AddCell />;
+        }
         return <ReviewSummaryCell summary={item.reviewSummary} />;
       default:
         return null;
@@ -91,9 +123,9 @@ const CompareTable = ({ items, className }: CompareTableProps) => {
               {row.label}
             </h3>
           )}
-          <div className="flex gap-[2.4rem]">
+          <div className={cn("grid gap-[2.4rem]", getGridCols(items.length))}>
             {items.map((item) => (
-              <div key={`${row.key}-${item.id}`} className="flex-1">
+              <div key={`${row.key}-${item.id}`}>
                 {renderCellContent(item, row.key)}
               </div>
             ))}

--- a/apps/web/src/domains/compare/components/compare-table/nearby-attractions-cell.tsx
+++ b/apps/web/src/domains/compare/components/compare-table/nearby-attractions-cell.tsx
@@ -3,11 +3,11 @@ import TablePlacesContents from "@/domains/compare/components/table-places-conte
 import type { Accommodation } from "@/domains/compare/types";
 
 interface NearbyAttractionsCellProps {
-  attractions: Accommodation["nearbyAttractions"];
+  attractions: NonNullable<Accommodation["nearbyAttractions"]>;
 }
 
 const NearbyAttractionsCell = ({ attractions }: NearbyAttractionsCellProps) => {
-  const contents = (attractions || []).map((attraction) => ({
+  const contents = attractions.map((attraction) => ({
     text: attraction.name || "",
     label: attraction.byCar?.time || "",
     icon: <IcCar />,

--- a/apps/web/src/domains/compare/components/compare-table/nearby-transportation-cell.tsx
+++ b/apps/web/src/domains/compare/components/compare-table/nearby-transportation-cell.tsx
@@ -3,13 +3,13 @@ import TablePlacesContents from "@/domains/compare/components/table-places-conte
 import type { Accommodation } from "@/domains/compare/types";
 
 interface NearbyTransportationCellProps {
-  transportation: Accommodation["nearbyTransportation"];
+  transportation: NonNullable<Accommodation["nearbyTransportation"]>;
 }
 
 const NearbyTransportationCell = ({
   transportation,
 }: NearbyTransportationCellProps) => {
-  const contents = (transportation || []).map((transport) => ({
+  const contents = transportation.map((transport) => ({
     text: transport.name || "",
     label: transport.byCar?.time || "",
     icon: <IcCar />,

--- a/apps/web/src/domains/compare/components/compare-table/review-score-cell.tsx
+++ b/apps/web/src/domains/compare/components/compare-table/review-score-cell.tsx
@@ -1,7 +1,7 @@
 import { Graph, IcStarFull } from "@ssok/ui";
 
 interface ReviewScoreCellProps {
-  score?: number;
+  score: number;
 }
 
 const ReviewScoreCell = ({ score }: ReviewScoreCellProps) => {
@@ -13,12 +13,10 @@ const ReviewScoreCell = ({ score }: ReviewScoreCellProps) => {
     return "매우 불만족";
   };
 
-  const safeScore = score || 0;
-
   return (
     <Graph
-      value={safeScore}
-      label={getLabel(safeScore)}
+      value={score}
+      label={getLabel(score)}
       icon={<IcStarFull />}
       showGraph={false}
     />

--- a/apps/web/src/domains/compare/components/compare-table/review-summary-cell.tsx
+++ b/apps/web/src/domains/compare/components/compare-table/review-summary-cell.tsx
@@ -1,11 +1,11 @@
 interface ReviewSummaryCellProps {
-  summary?: string;
+  summary: string;
 }
 
 const ReviewSummaryCell = ({ summary }: ReviewSummaryCellProps) => {
   return (
     <section className="flex rounded-[1.2rem] bg-neutral-98 p-[1.6rem] text-body1-semi16 text-neutral-30">
-      {summary || "리뷰 요약 없음"}
+      {summary}
     </section>
   );
 };

--- a/apps/web/src/domains/compare/hooks/use-compare-data.ts
+++ b/apps/web/src/domains/compare/hooks/use-compare-data.ts
@@ -165,35 +165,6 @@ const mockCompareData: Accommodation[] = [
     ],
     reviewScore: 9.2,
     cleanlinessScore: 9.5,
-    nearbyAttractions: [
-      {
-        name: "시부야",
-        type: "DISTRICT",
-        latitude: 35.658,
-        longitude: 139.7016,
-        distance: "100m",
-        byFoot: { distance: "100m", time: "1분" },
-        byCar: { distance: "100m", time: "1분" },
-      },
-      {
-        name: "하라주쿠",
-        type: "SHOPPING",
-        latitude: 35.6702,
-        longitude: 139.7038,
-        distance: "1.2km",
-        byFoot: { distance: "1.2km", time: "15분" },
-        byCar: { distance: "1.2km", time: "5분" },
-      },
-      {
-        name: "메이지신궁",
-        type: "SHRINE",
-        latitude: 35.6764,
-        longitude: 139.6993,
-        distance: "2km",
-        byFoot: { distance: "2km", time: "25분" },
-        byCar: { distance: "2km", time: "8분" },
-      },
-    ],
     amenities: [
       {
         type: "무료 와이파이",
@@ -296,8 +267,6 @@ const mockCompareData: Accommodation[] = [
         description: "",
       },
     ],
-    checkInTime: { checkInTimeFrom: "16:00", checkInTimeTo: "24:00" },
-    checkOutTime: { checkInTimeFrom: "00:00", checkInTimeTo: "10:00" },
     nearbyTransportation: [
       {
         name: "신주쿠역",


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- AddCell 버튼을 추가하여 정보가 없는 필드는 사용자가 직접 채워 넣을 수 있도록 구현했습니다.
- (아직 수정 기능은 구현하지 않음)

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

<img width="975" height="514" alt="CleanShot 2025-08-01 at 23 20 42" src="https://github.com/user-attachments/assets/507936ac-4515-4758-aaeb-70d995427119" />

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
commit-id:f5c87653

---

**Stack**:
- #87
- #86
- #85
- #84
- #83 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 데이터가 없는 비교 테이블 셀에 "내용 보충하기" 버튼이 추가되어, 누락된 정보를 쉽게 확인할 수 있습니다.

* **버그 수정**
  * 비교 테이블에서 일부 셀의 데이터 타입이 명확하게 지정되어, 정보가 없는 경우 일관된 처리와 표시가 이루어집니다.

* **스타일**
  * 비교 테이블의 셀 레이아웃이 플렉스박스에서 반응형 그리드로 개선되어, 항목 수에 따라 보기 편하게 정렬됩니다.

* **기타**
  * 일부 숙소의 모의 데이터에서 주변 명소 및 체크인/체크아웃 시간이 제거되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->