### PR TITLE
[Y26W2-126] feat(web): 비교표 페이지 뷰 모드 구현

### DIFF
--- a/apps/web/src/app/boards/[id]/layout.tsx
+++ b/apps/web/src/app/boards/[id]/layout.tsx
@@ -4,10 +4,12 @@ import SideNavigation from "@/shared/components/side-navigation";
 
 const BoardsIdLayout = ({ children }: PropsWithChildren) => {
   return (
-    <div className="flex h-screen">
+    <div className="flex h-screen w-full">
       <SideNavigation />
-      {children}
-      <MapComponent />
+      <div className="relative flex flex-1">
+        {children}
+        <MapComponent className="transition-all duration-500 ease-in-out" />
+      </div>
     </div>
   );
 };

--- a/apps/web/src/domains/compare/components/compare-page-title/index.tsx
+++ b/apps/web/src/domains/compare/components/compare-page-title/index.tsx
@@ -1,24 +1,45 @@
-import { Button, cn, IcEdit, IcMap, IcShare } from "@ssok/ui";
+import { Button, cn, IcEdit, IcMap, IcShare, IcTable } from "@ssok/ui";
+import type { ViewMode } from "@/domains/compare/hooks/use-view-mode";
 
 interface ComparePageTitleProps {
   title: string;
+  currentView: ViewMode;
+  onViewChange: (view: ViewMode) => void;
   className?: string;
 }
 
-const ComparePageTitle = ({ title, className }: ComparePageTitleProps) => {
+const ComparePageTitle = ({
+  title,
+  currentView,
+  onViewChange,
+  className,
+}: ComparePageTitleProps) => {
   return (
     <div
       className={cn("flex items-center justify-between px-[0.8rem]", className)}
     >
       <h1 className="text-neutral-30 text-title2-medi28">{title}</h1>
       <div className="flex gap-[0.8rem]">
-        <Button
-          size="lg"
-          variant="text"
-          icon={<IcMap width="20" height="20" />}
-        >
-          지도뷰
-        </Button>
+        {currentView === "table" && (
+          <Button
+            size="lg"
+            variant="text"
+            icon={<IcMap width="20" height="20" />}
+            onClick={() => onViewChange("map")}
+          >
+            지도뷰
+          </Button>
+        )}
+        {currentView === "map" && (
+          <Button
+            size="lg"
+            variant="text"
+            icon={<IcTable width="20" height="20" />}
+            onClick={() => onViewChange("table")}
+          >
+            표만보기
+          </Button>
+        )}
         <Button
           size="lg"
           variant="secondary"

--- a/apps/web/src/domains/compare/hooks/use-view-mode.ts
+++ b/apps/web/src/domains/compare/hooks/use-view-mode.ts
@@ -1,0 +1,28 @@
+import { useRouter, useSearchParams } from "next/navigation";
+import { useCallback, useMemo } from "react";
+
+export type ViewMode = "table" | "map";
+
+export const useViewMode = () => {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+
+  const currentView: ViewMode = useMemo(() => {
+    const view = searchParams.get("view");
+    if (view === "table" || view === "map") {
+      return view;
+    }
+    return "table";
+  }, [searchParams]);
+
+  const handleViewChange = useCallback(
+    (view: ViewMode) => {
+      const params = new URLSearchParams(searchParams);
+      params.set("view", view);
+      router.replace(`?${params.toString()}`);
+    },
+    [searchParams, router],
+  );
+
+  return { currentView, handleViewChange };
+};

--- a/apps/web/src/domains/compare/views/compare-page-view/index.tsx
+++ b/apps/web/src/domains/compare/views/compare-page-view/index.tsx
@@ -1,9 +1,11 @@
 "use client";
 
+import { cn } from "@ssok/ui";
 import ComparePageHeader from "@/domains/compare/components/compare-page-header";
 import ComparePageTitle from "@/domains/compare/components/compare-page-title";
 import CompareTable from "@/domains/compare/components/compare-table";
 import { useCompareData } from "@/domains/compare/hooks/use-compare-data";
+import { useViewMode } from "@/domains/compare/hooks/use-view-mode";
 
 interface ComparePageViewProps {
   compareId: string;
@@ -11,9 +13,16 @@ interface ComparePageViewProps {
 
 const ComparePageView = ({ compareId }: ComparePageViewProps) => {
   const { compareItems } = useCompareData(compareId);
+  const { currentView, handleViewChange } = useViewMode();
 
   return (
-    <main className="flex h-screen flex-col bg-neutral-98 p-[2.4rem]">
+    <main
+      className={cn(
+        "flex h-screen flex-col bg-neutral-98 p-[2.4rem] transition-all duration-500 ease-in-out",
+        currentView === "table" && "w-full [&+div]:w-0",
+        currentView === "map" && "w-[min(71.6rem,100%)] shrink-0",
+      )}
+    >
       <ComparePageHeader
         title="직장 동료들과 라멘 뿌수기"
         creator="이지수님"
@@ -21,7 +30,13 @@ const ComparePageView = ({ compareId }: ComparePageViewProps) => {
         count={compareItems.length}
         className="mb-[1.6rem]"
       />
-      <ComparePageTitle title="도쿄 숙소" className="mb-[3.2rem]" />
+      <ComparePageTitle
+        title="도쿄 숙소"
+        currentView={currentView}
+        onViewChange={handleViewChange}
+        className="mb-[3.2rem]"
+      />
+
       <CompareTable items={compareItems} />
     </main>
   );

--- a/apps/web/src/shared/components/map-component/index.tsx
+++ b/apps/web/src/shared/components/map-component/index.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import { cn } from "@ssok/ui";
 import GoogleMapReact from "google-map-react";
 import MapPin from "@/shared/components/map-component/map-pin";
 import { calculateCenter } from "@/shared/utils/map";
@@ -18,8 +19,8 @@ const locMock = [
   { id: 5, latitude: 37.4563, longitude: 126.7052, label: "인천 어쩌구 숙소" },
 ];
 
-const MapComponent = () => (
-  <div className="relative h-screen w-full">
+const MapComponent = ({ className }: { className?: string }) => (
+  <div className={cn("relative h-screen w-full", className)}>
     <GoogleMapReact
       bootstrapURLKeys={{
         key: process.env.NEXT_PUBLIC_GOOGLE_MAP_API_KEY,


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 비교표의 페이지 뷰 모드를 전환할 수 있도록 구현했습니다.
  - 쿼리 파라미터를 사용합니다. (ex. `?view=map`, `?view=table`)
- 아직 완벽하게 동작하지 않는 상태로, https://github.com/YAPP-Github/26th-Web-Team-2-FE/pull/86 에서 완벽하게 동작합니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

https://github.com/user-attachments/assets/02091a23-5a81-4640-af1a-3bd52b95a248

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
commit-id:33913df5

---

**Stack**:
- #87
- #86
- #85
- #84 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->
