### PR TITLE
[Y26W2-126] fix(web): TableTimeContents 간격 수정

### DIFF
--- a/apps/web/src/domains/compare/components/table-time-contents/index.tsx
+++ b/apps/web/src/domains/compare/components/table-time-contents/index.tsx
@@ -12,7 +12,7 @@ const TableTimeContents = ({
   checkOutAt,
 }: TableTimeContentsProps) => {
   return (
-    <section className="flex items-center overflow-hidden rounded-[1.2rem] bg-neutral-98 p-[1.6rem]">
+    <section className="flex items-center justify-between overflow-hidden rounded-[1.2rem] bg-neutral-98 p-[1.6rem]">
       <Time date={checkInAt} />
       <span className="flex-shrink-0 text-neutral-60">
         <SymbolTableTimeRightArrow width="20" />


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 체크인 / 아웃 시간 컴포넌트의 간격을 수정했습니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->
<img width="320" height="77" alt="CleanShot 2025-08-01 at 23 23 56" src="https://github.com/user-attachments/assets/a0f05a5a-ac5d-4ece-839e-a8605792563e" />
<img width="601" height="72" alt="CleanShot 2025-08-01 at 23 24 10" src="https://github.com/user-attachments/assets/7efad813-547e-4eda-81e0-8781ebcd1e02" />

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
commit-id:daaceff3

---

**Stack**:
- #87
- #86
- #85 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->
