### PR TITLE
[Y26W2-126] feat(ui): IcPlusCircle(ic_plus_circle) 아이콘 추가

### DIFF
--- a/packages/ui/src/assets/icons/ic_plus_circle.svg
+++ b/packages/ui/src/assets/icons/ic_plus_circle.svg
@@ -1,0 +1,3 @@
+<svg width="25" height="24" viewBox="0 0 25 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+<path d="M12.5 8V16M8.5 12H16.5M22.5 12C22.5 17.5228 18.0228 22 12.5 22C6.97715 22 2.5 17.5228 2.5 12C2.5 6.47715 6.97715 2 12.5 2C18.0228 2 22.5 6.47715 22.5 12Z" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+</svg>

--- a/packages/ui/src/foundations/icons.stories.tsx
+++ b/packages/ui/src/foundations/icons.stories.tsx
@@ -30,6 +30,7 @@ import IcLuggage from "@/assets/icons/ic_luggage.svg?react";
 import IcMap from "@/assets/icons/ic_map.svg?react";
 import IcMemo from "@/assets/icons/ic_memo.svg?react";
 import IcPets from "@/assets/icons/ic_pets.svg?react";
+import IcPlusCircle from "@/assets/icons/ic_plus_circle.svg?react";
 import IcPointOfSale from "@/assets/icons/ic_point_of_sale.svg?react";
 import IcPool from "@/assets/icons/ic_pool.svg?react";
 import IcRestaurant from "@/assets/icons/ic_restaurant.svg?react";
@@ -78,6 +79,7 @@ const icons = {
   IcMemo,
   IcPets,
   IcPointOfSale,
+  IcPlusCircle,
   IcPool,
   IcRestaurant,
   IcRoundPlus,

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -30,6 +30,7 @@ export { default as IcLuggage } from "@/assets/icons/ic_luggage.svg?react";
 export { default as IcMap } from "@/assets/icons/ic_map.svg?react";
 export { default as IcMemo } from "@/assets/icons/ic_memo.svg?react";
 export { default as IcPets } from "@/assets/icons/ic_pets.svg?react";
+export { default as IcPlusCircle } from "@/assets/icons/ic_plus_circle.svg?react";
 export { default as IcPointOfSale } from "@/assets/icons/ic_point_of_sale.svg?react";
 export { default as IcPool } from "@/assets/icons/ic_pool.svg?react";
 export { default as IcRestaurant } from "@/assets/icons/ic_restaurant.svg?react";


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- IcPlusCircle 아이콘을 추가했습니다. (비교 호텔 추가하기 컴포넌트에서 사용 예정)

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

<img width="398" height="171" alt="CleanShot 2025-08-02 at 00 39 23" src="https://github.com/user-attachments/assets/fddf7d06-e3fb-456e-aabf-dafef8382017" />

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
commit-id:bb91c0f8

---

**Stack**:
- #92
- #91
- #90
- #89
- #88 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * 새로운 IcPlusCircle 아이콘이 추가되어 아이콘 라이브러리 및 스토리북에서 사용할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->