### PR TITLE
[Y26W2-126] feat(web): 비교표 페이지 제목 수정 기능 구현

### DIFF
--- a/apps/web/src/domains/compare/components/compare-page-title/index.tsx
+++ b/apps/web/src/domains/compare/components/compare-page-title/index.tsx
@@ -1,10 +1,12 @@
 import { Button, cn, IcEdit, IcMap, IcSave, IcShare, IcTable } from "@ssok/ui";
 import type { ViewMode } from "@/domains/compare/hooks/use-view-mode";
+import PageTitle from "./page-title";
 
 interface ComparePageTitleProps {
   title: string;
   currentView: ViewMode;
   onViewChange: (view: ViewMode) => void;
+  onTitleChange?: (newTitle: string) => void;
   className?: string;
 }
 
@@ -12,13 +14,16 @@ const ComparePageTitle = ({
   title,
   currentView,
   onViewChange,
+  onTitleChange,
   className,
 }: ComparePageTitleProps) => {
   return (
-    <div
-      className={cn("flex items-center justify-between px-[0.8rem]", className)}
-    >
-      <h1 className="text-neutral-30 text-title2-medi28">{title}</h1>
+    <div className={cn("flex items-center justify-between", className)}>
+      <PageTitle
+        title={title}
+        isEditingAvailable={currentView === "edit"}
+        onTitleChange={onTitleChange}
+      />
       <div className="flex gap-[0.8rem]">
         {currentView === "table" && (
           <>

--- a/apps/web/src/domains/compare/components/compare-page-title/page-title.tsx
+++ b/apps/web/src/domains/compare/components/compare-page-title/page-title.tsx
@@ -1,0 +1,92 @@
+import { cn, IcEdit } from "@ssok/ui";
+import { useEffect, useRef, useState } from "react";
+import InputAutosize from "@/shared/components/input-autosize";
+
+interface PageTitleProps {
+  title: string;
+  isEditingAvailable?: boolean;
+  onTitleChange?: (newTitle: string) => void;
+  className?: string;
+}
+
+const PageTitle = ({
+  title,
+  isEditingAvailable,
+  onTitleChange,
+  className,
+}: PageTitleProps) => {
+  const [isEditing, setIsEditing] = useState(false);
+  const [value, setValue] = useState(title);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const isEditingNow = isEditingAvailable && isEditing;
+
+  useEffect(() => {
+    setValue(title);
+  }, [title]);
+
+  const handleClick = () => {
+    if (!isEditingAvailable) {
+      return;
+    }
+
+    setIsEditing(true);
+    if (inputRef.current) {
+      inputRef.current.focus();
+      inputRef.current.select();
+    }
+  };
+
+  const handleSave = () => {
+    setIsEditing(false);
+    if (value.trim() !== title && onTitleChange) {
+      onTitleChange(value.trim());
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === "Enter") {
+      handleSave();
+    } else if (e.key === "Escape") {
+      setIsEditing(false);
+      setValue(title);
+    }
+  };
+
+  const handleBlur = () => {
+    handleSave();
+  };
+
+  return (
+    <button
+      type="button"
+      onClick={handleClick}
+      className={cn(
+        "group flex cursor-pointer items-center gap-[1rem] rounded-[1.2rem] px-[0.8rem] py-[0.3rem] transition-colors duration-200",
+        isEditingAvailable && "cursor-pointer hover:bg-neutral-90",
+        isEditingNow && "bg-neutral-90",
+        className,
+      )}
+    >
+      <InputAutosize
+        ref={inputRef}
+        value={value}
+        onChange={(e) => setValue(e.target.value)}
+        onKeyDown={handleKeyDown}
+        onBlur={handleBlur}
+        readOnly={!isEditingAvailable}
+        disabled={!isEditingAvailable}
+        className="bg-transparent text-neutral-30 text-title2-medi28 [&>input]:outline-none"
+      />
+      {isEditingAvailable && !isEditingNow && (
+        <IcEdit
+          width="20"
+          height="20"
+          className="text-neutral-70 opacity-0 transition-opacity duration-200 group-hover:opacity-100"
+        />
+      )}
+    </button>
+  );
+};
+
+export default PageTitle;

--- a/apps/web/src/shared/components/input-autosize/index.tsx
+++ b/apps/web/src/shared/components/input-autosize/index.tsx
@@ -1,0 +1,26 @@
+import { cn } from "@ssok/ui";
+import type { ComponentProps } from "react";
+
+const InputAutosize = ({
+  value,
+  className,
+  ...props
+}: ComponentProps<"input">) => {
+  return (
+    <div className={cn("grid", className)}>
+      <span className="invisible [grid-area:1/1]">
+        {!String(value) && "\u00A0"}
+        {String(value).replace(/ /g, "\u00A0")}
+      </span>
+      <input
+        size={1}
+        type="text"
+        value={value}
+        className="[grid-area:1/1]"
+        {...props}
+      />
+    </div>
+  );
+};
+
+export default InputAutosize;


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 비교표 페이지의 제목 수정 기능을 구현했습니다.
- Input의 크기를 자동으로 조절하기 위한 간단한 유틸 컴포넌트도 함께 구현했습니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

https://github.com/user-attachments/assets/8caecf86-d64b-4c1f-9947-8e39a3acbbbb


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
commit-id:1790e5ea

---

**Stack**:
- #92
- #91
- #90 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 제목을 인라인으로 편집할 수 있는 기능이 추가되었습니다. 이제 제목을 클릭하면 직접 수정이 가능합니다.
  * 입력 내용에 따라 자동으로 크기가 조절되는 입력 필드가 제공됩니다.

* **스타일**
  * 제목 영역의 패딩이 조정되어 레이아웃이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->