### PR TITLE
[Y26W2-225] fix(web): 스크롤 이벤트 로직과 로딩 분기 개선 

### DIFF
--- a/apps/web/src/app/boards/[id]/lists/page.tsx
+++ b/apps/web/src/app/boards/[id]/lists/page.tsx
@@ -91,7 +91,6 @@ const BoardsIdListsPage = () => {
               isInputExpanded={isInputExpanded}
               isMemoInputVisible={isMemoInputVisible}
               isTooltipVisible={isTooltipVisible}
-              handleCloseInputExpansion={handleCloseInputExpansion}
               toggleInputExpansion={toggleInputExpansion}
               handleMemoInputToggle={handleMemoInputToggle}
               handleTooltipvisible={handleTooltipvisible}
@@ -106,6 +105,8 @@ const BoardsIdListsPage = () => {
               handlePersonSelect={handlePersonSelect}
               handleFilterSelect={handleFilterSelect}
               handleToggleDropdown={handleToggleDropdown}
+              handdleCloseInputExpansion={handleCloseInputExpansion}
+              isInputExpanded={isInputExpanded}
               isOpen={isOpen}
               selectedFilter={selectedFilter}
               isLoading={isLoading}

--- a/apps/web/src/app/boards/[id]/lists/page.tsx
+++ b/apps/web/src/app/boards/[id]/lists/page.tsx
@@ -108,6 +108,7 @@ const BoardsIdListsPage = () => {
               handleToggleDropdown={handleToggleDropdown}
               isOpen={isOpen}
               selectedFilter={selectedFilter}
+              isLoading={isLoading}
             />
           </motion.div>
         )}
@@ -122,7 +123,7 @@ const BoardsIdListsPage = () => {
         )}
       />
       {isLoading && (
-        <main className="absolute z-10 flex h-full w-full items-center justify-center">
+        <main className="absolute z-10 flex h-full w-full items-center justify-center ">
           <div
             className={`h-[2.4rem] w-[2.4rem] animate-spin rounded-full border-4 border-t-transparent bg-primary`}
           />

--- a/apps/web/src/app/boards/[id]/lists/page.tsx
+++ b/apps/web/src/app/boards/[id]/lists/page.tsx
@@ -116,7 +116,7 @@ const BoardsIdListsPage = () => {
       </AnimatePresence>
       {/* TODO: resize 추가 애니메이션 보강  */}
       <SolidExpand
-        expand={isPanelExpanded}
+        collapse={!isPanelExpanded}
         onClick={handlePanelToggle}
         className={cn(
           "absolute top-[50%] z-2",

--- a/apps/web/src/domains/list/components/link-input-section/index.tsx
+++ b/apps/web/src/domains/list/components/link-input-section/index.tsx
@@ -1,6 +1,5 @@
 import { useRegisterAccommodationCard } from "@ssok/api";
 import { cn, IcLink } from "@ssok/ui";
-import { useEffect } from "react";
 import type {
   FieldErrors,
   UseFormHandleSubmit,
@@ -22,7 +21,6 @@ type LinkInputSectionProps = {
   isInputExpanded: boolean;
   isTooltipVisible: boolean;
   isMemoInputVisible: boolean;
-  handleCloseInputExpansion: () => void;
   toggleInputExpansion: () => void;
   handleMemoInputToggle: () => void;
   handleTooltipvisible: (visible: boolean) => void;
@@ -38,7 +36,6 @@ const LinkInputSection = ({
   isInputExpanded,
   isTooltipVisible,
   isMemoInputVisible,
-  handleCloseInputExpansion,
   toggleInputExpansion,
   handleMemoInputToggle,
   handleTooltipvisible,
@@ -49,29 +46,6 @@ const LinkInputSection = ({
   maxChars,
 }: LinkInputSectionProps) => {
   const { mutate, isPending } = useRegisterAccommodationCard();
-  useEffect(() => {
-    if (localStorage.getItem("onboardingStep") !== "finish") return;
-    let timer: ReturnType<typeof setTimeout> | null = null;
-
-    const handleScroll = () => {
-      if (timer) {
-        clearTimeout(timer);
-      }
-
-      if (isInputExpanded) {
-        timer = setTimeout(() => {
-          handleCloseInputExpansion();
-        }, 200);
-      }
-    };
-
-    window.addEventListener("scroll", handleScroll, { passive: true });
-
-    return () => {
-      window.removeEventListener("scroll", handleScroll);
-      if (timer) clearTimeout(timer);
-    };
-  }, [isInputExpanded, handleCloseInputExpansion]);
 
   const onValid = (data: FormData) => {
     // TODO: boardId와 userId는 추후에 실제 값으로 변경

--- a/apps/web/src/domains/list/components/place-list-section/index.tsx
+++ b/apps/web/src/domains/list/components/place-list-section/index.tsx
@@ -1,5 +1,5 @@
 import { Button, Card, cn } from "@ssok/ui";
-import { useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useAccommodationContext } from "../../contexts/accomodation-context";
 import { useMemberData } from "../../hooks/use-member-data";
 import DropDown from "./atom/drop-down";
@@ -10,6 +10,8 @@ type PlaceListSectionProps = {
   handlePersonSelect: (id: number) => void;
   handleFilterSelect: (id: string) => void;
   handleToggleDropdown: () => void;
+  handdleCloseInputExpansion: () => void;
+  isInputExpanded: boolean;
   isOpen: boolean;
   selectedFilter: string;
   isLoading: boolean;
@@ -20,6 +22,8 @@ const PlaceListSection = ({
   handlePersonSelect,
   handleFilterSelect,
   handleToggleDropdown,
+  handdleCloseInputExpansion,
+  isInputExpanded,
   isOpen,
   selectedFilter,
   isLoading,
@@ -28,6 +32,34 @@ const PlaceListSection = ({
   const memberData = useMemberData();
   // const accommodationData = useAccommodationData();
   const { accommodations } = useAccommodationContext();
+  const listRef = useRef<HTMLUListElement | null>(null);
+
+  useEffect(() => {
+    if (localStorage.getItem("onboardingStep") !== "finish" && !isInputExpanded)
+      return;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const handleScroll = () => {
+      if (timer) clearTimeout(timer);
+      if (isInputExpanded) {
+        timer = setTimeout(() => {
+          handdleCloseInputExpansion();
+        }, 50);
+      }
+    };
+
+    const listElement = listRef.current;
+    if (listElement) {
+      listElement.addEventListener("scroll", handleScroll, { passive: true });
+    }
+
+    return () => {
+      if (listElement) {
+        listElement.removeEventListener("scroll", handleScroll);
+      }
+      if (timer) clearTimeout(timer);
+    };
+  }, [isInputExpanded, handdleCloseInputExpansion]);
 
   const handlePlaceSelect = (placeName: string) => {
     setSelectedPlaces((prev) =>
@@ -45,7 +77,7 @@ const PlaceListSection = ({
     <section
       className={cn(
         "rounded-2xl border border-neutral-90 bg-neutral-100",
-        "w-max overflow-visible p-[2.4rem]",
+        "w-max p-[2.4rem]",
       )}
     >
       {/* 숙소 리스트_제목 */}
@@ -75,7 +107,10 @@ const PlaceListSection = ({
         </div>
       </div>
       {/* 숙소 리스트_카드목록 */}
-      <ul className="flex h-[40rem] min-w-[60rem] flex-col gap-[1.2rem] overflow-y-auto">
+      <ul
+        ref={listRef}
+        className="flex h-[40rem] min-w-[60rem] flex-col gap-[1.2rem] overflow-y-scroll"
+      >
         {accommodations?.map((place) => (
           <li key={`${place.hotelId}-card`}>
             <Card

--- a/apps/web/src/domains/list/components/place-list-section/index.tsx
+++ b/apps/web/src/domains/list/components/place-list-section/index.tsx
@@ -12,6 +12,7 @@ type PlaceListSectionProps = {
   handleToggleDropdown: () => void;
   isOpen: boolean;
   selectedFilter: string;
+  isLoading: boolean;
 };
 
 const PlaceListSection = ({
@@ -21,6 +22,7 @@ const PlaceListSection = ({
   handleToggleDropdown,
   isOpen,
   selectedFilter,
+  isLoading,
 }: PlaceListSectionProps) => {
   const [selectedPlaces, setSelectedPlaces] = useState<string[]>([]);
   const memberData = useMemberData();
@@ -73,7 +75,7 @@ const PlaceListSection = ({
         </div>
       </div>
       {/* 숙소 리스트_카드목록 */}
-      <ul className="flex max-h-[40rem] flex-col gap-[1.2rem] overflow-y-auto">
+      <ul className="flex h-[40rem] min-w-[60rem] flex-col gap-[1.2rem] overflow-y-auto">
         {accommodations?.map((place) => (
           <li key={`${place.hotelId}-card`}>
             <Card
@@ -106,7 +108,7 @@ const PlaceListSection = ({
             />
           </li>
         ))}
-        {(!accommodations || accommodations.length === 0) && (
+        {!isLoading && (!accommodations || accommodations.length === 0) && (
           <EmptyListContainer />
         )}
       </ul>

--- a/packages/ui/src/components/icon-button/solid-expand/index.tsx
+++ b/packages/ui/src/components/icon-button/solid-expand/index.tsx
@@ -5,7 +5,7 @@ import { cn } from "@/utils";
 
 type SolidExpandProps = {
   className?: string;
-  expand: boolean;
+  collapse: boolean;
   onMouseDown?: () => void;
   onMouseUp?: () => void;
   onMouseLeave?: () => void;
@@ -13,7 +13,7 @@ type SolidExpandProps = {
 
 export const SolidExpand = ({
   className,
-  expand,
+  collapse,
   onMouseDown,
   onMouseUp,
   onMouseLeave,
@@ -29,13 +29,13 @@ export const SolidExpand = ({
         "inline-flex cursor-pointer rounded-tr-[16px] rounded-br-[16px] py-[1.6rem] pr-[0.6rem] pl-[0.2rem] disabled:cursor-not-allowed",
         "border-t border-r border-b border-l-0",
         "border-neutral-70 bg-neutral-98", // default
-        !expand && "hover:bg-neutral-95 focus:bg-neutral-90", // hover, focused
+        !collapse && "hover:bg-neutral-95 focus:bg-neutral-90", // hover, focused
         className,
       )}
       {...props}
     >
-      {!expand && <IcArrowLeft width="32px" height="32px" />}
-      {expand && <IcArrowRight width="32px" height="32px" />}
+      {!collapse && <IcArrowLeft width="32px" height="32px" />}
+      {collapse && <IcArrowRight width="32px" height="32px" />}
     </button>
   );
 };


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 숙소 목록 스크롤시, `expandInput` 이 자동으로 닫히도록 수정했습니다 
   - (기존엔 전체 section에 대해서 감지했는데, 현재는 100vh로 높이가 고정되면서 전체 영역에 대한 스크롤이 불가능해졌기 때문에 숙소 리스트를 나타내는 ul 태그에 해당 이벤트를 걸게 되었습니다 ) 
- 또한, 데이터 `isLoading` 상태에서 `emptyListContainer`가 랜더링되지 않도록 수정했습니다. 

## ✅ 체크리스트

- [x] 기능 동작 확인
- [ ] 코드 리뷰 반영
- [ ] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

[스크롤 로직 관련 시연]
https://github.com/user-attachments/assets/12484e69-156d-4fc3-89c2-a0feca68c4df

[isLoading 스피너 ]
https://github.com/user-attachments/assets/2f97bfbe-892e-4b00-bdbd-6dc81d3655a8


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->
