### PR TITLE
[Y26W2-126] fix(web): 누락된 loop 내 key prop 추가

### DIFF
--- a/apps/web/src/domains/compare/components/table-amenities-contents/index.tsx
+++ b/apps/web/src/domains/compare/components/table-amenities-contents/index.tsx
@@ -1,5 +1,5 @@
 import { Chip, TextField } from "@ssok/ui";
-import type { ReactNode } from "react";
+import { Fragment, type ReactNode } from "react";
 import type { ViewState } from "@/domains/compare/types";
 
 export interface TableAmenitiesContentsProps {
@@ -18,7 +18,7 @@ const TableAmenitiesContents = ({
   return (
     <section className="flex flex-col gap-[1.6rem] rounded-[1.2rem] bg-neutral-98 p-[1.6rem]">
       {contents.map((content) => (
-        <>
+        <Fragment key={content.text}>
           {state !== "edit" && (
             <div key={content.text} className="flex items-center gap-[0.8rem]">
               <span className="flex-shrink-0 text-neutral-60">
@@ -54,7 +54,7 @@ const TableAmenitiesContents = ({
               />
             </div>
           )}
-        </>
+        </Fragment>
       ))}
     </section>
   );

--- a/apps/web/src/domains/compare/components/table-places-contents/index.tsx
+++ b/apps/web/src/domains/compare/components/table-places-contents/index.tsx
@@ -1,5 +1,5 @@
 import { Chip, IcCar, IcKm, IconTabs, IcWalker, TextField } from "@ssok/ui";
-import type { ReactNode } from "react";
+import { Fragment, type ReactNode } from "react";
 import type { ViewState } from "@/domains/compare/types";
 
 export interface TablePlacesContentsProps {
@@ -15,9 +15,9 @@ const TablePlacesContents = ({ contents, state }: TablePlacesContentsProps) => {
   return (
     <section className="flex flex-col gap-[1.6rem] rounded-[1.2rem] bg-neutral-98 p-[1.6rem]">
       {contents.map((content) => (
-        <>
+        <Fragment key={content.text}>
           {state !== "edit" && (
-            <div key={content.text}>
+            <div>
               <p className="mb-[0.4rem] text-body1-semi16 text-neutral-30">
                 {content.text}
               </p>
@@ -51,7 +51,7 @@ const TablePlacesContents = ({ contents, state }: TablePlacesContentsProps) => {
               </div>
             </div>
           )}
-        </>
+        </Fragment>
       ))}
     </section>
   );


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 누락된 `key` prop을 추가합니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
commit-id:9846f56b

---

**Stack**:
- #97
- #96 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 비교 테이블의 항목 목록 렌더링 시 React의 리스트 키 요구사항을 충족하도록 개선하여, 잠재적인 렌더링 경고 및 예기치 않은 동작을 방지했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->