### PR TITLE
[Y26W2-230] feat(ui,web): Textarea 컴포넌트 개발

### DIFF
--- a/apps/web/src/domains/compare/components/compare-table/review-summary-cell.tsx
+++ b/apps/web/src/domains/compare/components/compare-table/review-summary-cell.tsx
@@ -1,3 +1,4 @@
+import { Textarea } from "@ssok/ui";
 import type { ViewState } from "@/domains/compare/types";
 
 interface ReviewSummaryCellProps {
@@ -5,11 +6,9 @@ interface ReviewSummaryCellProps {
   state?: ViewState;
 }
 
-const ReviewSummaryCell = ({ summary }: ReviewSummaryCellProps) => {
+const ReviewSummaryCell = ({ summary, state }: ReviewSummaryCellProps) => {
   return (
-    <section className="flex rounded-[1.2rem] bg-neutral-98 p-[1.6rem] text-body1-semi16 text-neutral-30">
-      {summary}
-    </section>
+    <Textarea disabled={state !== "edit"} value={summary} maxLength={100} />
   );
 };
 

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -31,6 +31,7 @@
     "pretendard": "^1.3.9",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
+    "react-textarea-autosize": "^8.5.9",
     "tailwind-merge": "^3.3.0",
     "vite-plugin-dts": "^4.5.4"
   },

--- a/packages/ui/src/components/textarea/index.stories.tsx
+++ b/packages/ui/src/components/textarea/index.stories.tsx
@@ -1,0 +1,79 @@
+import type { Meta, StoryFn } from "@storybook/react-vite";
+import { useState } from "react";
+import { Textarea, type TextareaProps } from "@/components/textarea";
+
+const meta: Meta<TextareaProps> = {
+  title: "Components/Textarea",
+  component: Textarea,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  argTypes: {
+    hasError: {
+      control: "boolean",
+    },
+    placeholder: {
+      control: "text",
+    },
+    value: {
+      control: "text",
+    },
+    maxLength: {
+      control: "number",
+    },
+    minRows: {
+      control: "number",
+    },
+    maxRows: {
+      control: "number",
+    },
+    disabled: {
+      control: "boolean",
+    },
+  },
+  decorators: [
+    (Story) => (
+      <div className="mx-auto w-full max-w-[35.9rem]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+const Template: StoryFn<TextareaProps> = (args) => {
+  const [value, setValue] = useState(args.value || "");
+
+  return (
+    <Textarea
+      {...args}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    />
+  );
+};
+
+export const Default: StoryFn<TextareaProps> = Template.bind({});
+Default.args = {
+  placeholder: "텍스트를 입력해 주세요.",
+};
+
+export const WithMaxLength: StoryFn<TextareaProps> = Template.bind({});
+WithMaxLength.args = {
+  placeholder: "최대 100자까지 입력할 수 있습니다.",
+  maxLength: 100,
+};
+
+export const WithError: StoryFn<TextareaProps> = Template.bind({});
+WithError.args = {
+  value: "오류가 있는 텍스트입니다.",
+  hasError: true,
+};
+
+export const WithDisabled: StoryFn<TextareaProps> = Template.bind({});
+WithDisabled.args = {
+  value: "비활성화된 상태입니다.",
+  disabled: true,
+};
+
+export default meta;

--- a/packages/ui/src/components/textarea/index.tsx
+++ b/packages/ui/src/components/textarea/index.tsx
@@ -1,0 +1,63 @@
+import { cva, type VariantProps } from "class-variance-authority";
+import type { ComponentProps } from "react";
+import TextareaAutosize from "react-textarea-autosize";
+import { cn } from "@/utils";
+
+export interface TextareaProps
+  extends ComponentProps<typeof TextareaAutosize>,
+    VariantProps<typeof variants> {
+  maxLength?: number;
+}
+
+const variants = cva(
+  [
+    "w-full resize-none rounded-[1.2rem] border p-[1.6rem] outline-none",
+    "text-body1-medi16 text-neutral-30",
+    "transition-all duration-200",
+    "placeholder:text-body2-medi14 placeholder:text-neutral-80",
+    "disabled:cursor-default disabled:border-transparent disabled:bg-neutral-98 disabled:text-neutral-30",
+  ],
+  {
+    variants: {
+      hasError: {
+        true: "border-error-70 focus:border-transparent focus:shadow-[0_0_0_2px_theme(colors.error.70)]",
+        false:
+          "border-neutral-90 focus:border-transparent focus:shadow-[0_0_0_2px_theme(colors.neutral.80)]",
+      },
+    },
+    defaultVariants: {
+      hasError: false,
+    },
+  },
+);
+
+export const Textarea = ({
+  hasError = false,
+  minRows = 3,
+  maxRows = 10,
+  value = "",
+  maxLength,
+  className,
+  ...props
+}: TextareaProps) => {
+  const currentLength = String(value).length;
+
+  return (
+    <div className={cn("relative", className)}>
+      <TextareaAutosize
+        minRows={minRows}
+        maxRows={maxRows}
+        value={value}
+        maxLength={maxLength}
+        className={cn(variants({ hasError }), maxLength && "pb-[3.2rem]")}
+        {...props}
+      />
+      {maxLength && !props.disabled && (
+        <span className="pointer-events-none absolute right-[1.6rem] bottom-[1.6rem] text-caption1-medi12 text-neutral-70">
+          <span className="text-caption1-semi12">{currentLength}</span> /{" "}
+          {maxLength}
+        </span>
+      )}
+    </div>
+  );
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -60,6 +60,7 @@ export type { IconTabsOption, IconTabsProps } from "@/components/icon-tabs";
 export { IconTabs } from "@/components/icon-tabs";
 export { Pin } from "@/components/pin";
 export { TextField } from "@/components/text-field";
+export { Textarea } from "@/components/textarea";
 export { cn } from "@/utils";
 
 export { default as TextWithIcon } from "./components/text-with-icon";

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -263,6 +263,9 @@ importers:
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
+      react-textarea-autosize:
+        specifier: ^8.5.9
+        version: 8.5.9(@types/react@19.1.0)(react@19.1.0)
       tailwind-merge:
         specifier: ^3.3.0
         version: 3.3.1
@@ -6369,6 +6372,12 @@ packages:
     resolution: {integrity: sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==}
     engines: {node: '>=0.10.0'}
 
+  react-textarea-autosize@8.5.9:
+    resolution: {integrity: sha512-U1DGlIQN5AwgjTyOEnI1oCcMuEr1pv1qOtklB2l4nyMGbHzWrI0eFsYK0zos2YWqAolJyG0IWJaqWmWj5ETh0A==}
+    engines: {node: '>=10'}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
     engines: {node: '>=0.10.0'}
@@ -7276,6 +7285,33 @@ packages:
 
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
+
+  use-composed-ref@1.4.0:
+    resolution: {integrity: sha512-djviaxuOOh7wkj0paeO1Q/4wMZ8Zrnag5H6yBvzN7AKKe8beOaED9SF5/ByLqsku8NP4zQqsvM2u3ew/tJK8/w==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-isomorphic-layout-effect@1.2.1:
+    resolution: {integrity: sha512-tpZZ+EX0gaghDAiFR37hj5MgY6ZN55kLiPkJsKxBMZ6GZdOSPJXiOzPM984oPYZ5AnehYx5WQp1+ME8I/P/pRA==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+
+  use-latest@1.3.0:
+    resolution: {integrity: sha512-mhg3xdm9NaM8q+gLT8KryJPnRFOz1/5XPBhmDEVZK1webPzDjrPk7f/mbpeLqTgB9msytYWANxgALOCJKnLvcQ==}
+    peerDependencies:
+      '@types/react': '*'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
 
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
@@ -14156,6 +14192,15 @@ snapshots:
 
   react-refresh@0.17.0: {}
 
+  react-textarea-autosize@8.5.9(@types/react@19.1.0)(react@19.1.0):
+    dependencies:
+      '@babel/runtime': 7.27.6
+      react: 19.1.0
+      use-composed-ref: 1.4.0(@types/react@19.1.0)(react@19.1.0)
+      use-latest: 1.3.0(@types/react@19.1.0)(react@19.1.0)
+    transitivePeerDependencies:
+      - '@types/react'
+
   react@19.1.0: {}
 
   read-cache@1.0.0:
@@ -15234,6 +15279,25 @@ snapshots:
     dependencies:
       querystringify: 2.2.0
       requires-port: 1.0.0
+
+  use-composed-ref@1.4.0(@types/react@19.1.0)(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.0
+
+  use-isomorphic-layout-effect@1.2.1(@types/react@19.1.0)(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+    optionalDependencies:
+      '@types/react': 19.1.0
+
+  use-latest@1.3.0(@types/react@19.1.0)(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      use-isomorphic-layout-effect: 1.2.1(@types/react@19.1.0)(react@19.1.0)
+    optionalDependencies:
+      '@types/react': 19.1.0
 
   util-deprecate@1.0.2: {}
 


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- Textarea 컴포넌트를 개발하고, 기존의 ReviewSummaryCell에서 가져다 사용하도록 변경했습니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

<img width="1190" height="2310" alt="CleanShot 2025-08-05 at 09 59 40@2x" src="https://github.com/user-attachments/assets/efe8cf9b-09e0-4660-8084-bea4d2cc0eed" />

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
commit-id:f2c933f1

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 자동 크기 조절 및 글자 수 제한, 에러/비활성화 상태 지원하는 텍스트에어리어(Textarea) 컴포넌트가 추가되었습니다.
  * 리뷰 요약 셀에서 요약 내용을 조건부로 편집할 수 있도록 텍스트에어리어로 변경되었습니다.

* **문서화**
  * 텍스트에어리어 컴포넌트의 다양한 상태(기본, 글자수 제한, 에러, 비활성화)를 확인할 수 있는 Storybook 스토리가 추가되었습니다.

* **기타**
  * 텍스트에어리어 컴포넌트 사용을 위한 외부 라이브러리 의존성이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->