### PR TITLE
[Y26W2-232] feat(web): 숙소 리스트 api 무한스크롤 반영 

### DIFF
--- a/apps/web/src/app/boards/[id]/lists/page.tsx
+++ b/apps/web/src/app/boards/[id]/lists/page.tsx
@@ -40,12 +40,13 @@ const BoardsIdListsPage = () => {
     watch,
   } = useRegisterUrlInput();
 
-  const { data, isLoading } = useAccommodationList({
-    boardId: 1,
-    userId: selectedPerson === 0 ? undefined : selectedPerson,
-    size: 10,
-    sort: selectedFilter,
-  });
+  const { data, isLoading, fetchNextPage, hasNextPage, isFetchingNextPage } =
+    useAccommodationList({
+      boardId: 1,
+      userId: selectedPerson === 0 ? undefined : selectedPerson,
+      size: 3,
+      sort: selectedFilter,
+    });
 
   const { updateAccommodations } = useAccommodationDataContext();
   const { handlePanelToggle, isPanelExpanded } = usePanelContext();
@@ -109,6 +110,9 @@ const BoardsIdListsPage = () => {
               isOpen={isOpen}
               selectedFilter={selectedFilter}
               isLoading={isLoading}
+              fetchNextPage={fetchNextPage}
+              hasNextPage={hasNextPage}
+              isFetchingNextPage={isFetchingNextPage}
             />
           </motion.div>
         )}

--- a/apps/web/src/domains/list/components/place-list-section/index.tsx
+++ b/apps/web/src/domains/list/components/place-list-section/index.tsx
@@ -1,7 +1,8 @@
 import { Button, Card, cn } from "@ssok/ui";
-import { useEffect, useRef } from "react";
+import { useRef } from "react";
 import { useAccommodationDataContext } from "../../contexts/accomodation-data-context";
 import { usePlaceSelectionContext } from "../../contexts/place-select-context";
+import useCollapseOnScroll from "../../hooks/use-collapse-on-scroll";
 import useInfiniteScroll from "../../hooks/use-infinite-scroll";
 import { useMemberData } from "../../hooks/use-member-data";
 import DropDown from "./atom/drop-down";
@@ -48,32 +49,7 @@ const PlaceListSection = ({
     fetchNextPage,
   });
 
-  useEffect(() => {
-    if (localStorage.getItem("onboardingStep") !== "finish" && !isInputExpanded)
-      return;
-    let timer: ReturnType<typeof setTimeout> | null = null;
-
-    const handleScroll = () => {
-      if (timer) clearTimeout(timer);
-      if (isInputExpanded) {
-        timer = setTimeout(() => {
-          handleCloseInputExpansion();
-        }, 50);
-      }
-    };
-
-    const listElement = listRef.current;
-    if (listElement) {
-      listElement.addEventListener("scroll", handleScroll, { passive: true });
-    }
-
-    return () => {
-      if (listElement) {
-        listElement.removeEventListener("scroll", handleScroll);
-      }
-      if (timer) clearTimeout(timer);
-    };
-  }, [isInputExpanded, handleCloseInputExpansion]);
+  useCollapseOnScroll(listRef, isInputExpanded, handleCloseInputExpansion);
 
   return (
     <section

--- a/apps/web/src/domains/list/contexts/pannel-context.tsx
+++ b/apps/web/src/domains/list/contexts/pannel-context.tsx
@@ -11,7 +11,7 @@ type PanelContextType = {
 const PanelContext = createContext<PanelContextType | null>(null);
 
 export const PanelProvider = ({ children }: { children: ReactNode }) => {
-  const [isPanelExpanded, setIsPanelExpanded] = useState(false);
+  const [isPanelExpanded, setIsPanelExpanded] = useState(true);
 
   const handlePanelToggle = () => setIsPanelExpanded((prev) => !prev);
   const handlePanelExpand = () => setIsPanelExpanded(true);

--- a/apps/web/src/domains/list/hooks/use-collapse-on-scroll.ts
+++ b/apps/web/src/domains/list/hooks/use-collapse-on-scroll.ts
@@ -1,0 +1,57 @@
+import { type RefObject, useEffect } from "react";
+
+/**
+ * useCollapseOnScroll
+ *
+ * 특정 DOM 요소에서 스크롤 이벤트가 발생하면 입력창을 닫는 콜백 함수를 실행하는 커스텀 훅입니다.
+ *
+ * 이 훅은 `isInputExpanded`가 `true`이고, 로컬 스토리지의 `onboardingStep` 값이 `"finish"`인 경우에만 동작합니다.
+ * 스크롤 이벤트가 발생하면 50ms 내에 입력창 닫기 함수(`handleClose`)가 실행됩니다.
+ *
+ * @template T - DOM 요소의 타입 (`HTMLElement`의 서브타입)
+ *
+ * @param {RefObject<T>} ref - 스크롤 이벤트를 감지할 DOM 요소의 ref
+ * @param {boolean} isInputExpanded - 입력창이 확장되어 있는지 여부
+ * @param {() => void} handleClose - 입력창을 닫기 위한 콜백 함수
+ *
+ * @example
+ * const listRef = useRef<HTMLUListElement>(null);
+ * useCollapseOnScroll(listRef, isInputExpanded, handleCloseInputExpansion);
+ */
+const useCollapseOnScroll = <T extends HTMLElement | null>(
+  ref: RefObject<T>,
+  isInputExpanded: boolean,
+  handleClose: () => void,
+) => {
+  useEffect(() => {
+    if (localStorage.getItem("onboardingStep") !== "finish" && !isInputExpanded)
+      return;
+
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    const handleScroll = () => {
+      if (timer) clearTimeout(timer);
+      if (isInputExpanded) {
+        timer = setTimeout(() => {
+          handleClose();
+        }, 50);
+      }
+    };
+
+    if (!ref || !ref.current) return;
+
+    const listElement = ref.current;
+    if (listElement) {
+      listElement.addEventListener("scroll", handleScroll, { passive: true });
+    }
+
+    return () => {
+      if (listElement) {
+        listElement.removeEventListener("scroll", handleScroll);
+      }
+      if (timer) clearTimeout(timer);
+    };
+  }, [isInputExpanded, handleClose, ref]);
+};
+
+export default useCollapseOnScroll;

--- a/apps/web/src/domains/list/hooks/use-infinite-scroll.ts
+++ b/apps/web/src/domains/list/hooks/use-infinite-scroll.ts
@@ -1,0 +1,49 @@
+import { useCallback, useRef } from "react";
+
+type Params = {
+  isLoading: boolean;
+  hasNextPage?: boolean;
+  fetchNextPage: () => void;
+};
+
+/**
+ * 커스텀 훅: 무한 스크롤을 위한 IntersectionObserver를 설정합니다.
+ *
+ * 마지막 아이템 요소에 `ref`를 연결하면, 해당 요소가 viewport에 진입할 때 `fetchNextPage`가 호출됩니다.
+ *
+ * @param {Object} params - 훅에 전달할 인자 객체
+ * @param {boolean} params.isLoading - 데이터가 로딩 중인지 여부
+ * @param {boolean} [params.hasNextPage] - 다음 페이지가 존재하는지 여부
+ * @param {() => void} params.fetchNextPage - 다음 페이지를 불러오는 함수
+ *
+ * @returns {(node: HTMLLIElement | null) => void} - 마지막 아이템에 할당할 ref 콜백
+ *
+ */
+const useInfiniteScroll = ({
+  isLoading,
+  hasNextPage,
+  fetchNextPage,
+}: Params) => {
+  const observer = useRef<IntersectionObserver | null>(null);
+
+  const lastItemRef = useCallback(
+    (node: HTMLLIElement | null) => {
+      if (isLoading || !hasNextPage) return;
+
+      if (observer.current) observer.current.disconnect();
+
+      observer.current = new IntersectionObserver((entries) => {
+        if (entries[0].isIntersecting) {
+          fetchNextPage();
+        }
+      });
+
+      if (node) observer.current.observe(node);
+    },
+    [isLoading, hasNextPage, fetchNextPage],
+  );
+
+  return lastItemRef;
+};
+
+export default useInfiniteScroll;


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 숙소 조회 api에서 무한 스크롤로 랜더링이 가능하도록 코드를 추가했습니다
- place-list 컴포넌트에 로직을 추가하면서, **무한 스크롤 감지 부분**과 **스크롤 시 input 부분이 줄어드는 부분**을 따로 커스텀훅으로 각각 분리했습니다 (`useInfiniteScroll`,`useCollapseOnScroll`)

(스크롤 관련하여 훅이 2개 더 추가되고, 커스텀 훅이 많이진 것 같아  `/domains/list/hooks` 내부를 폴더로 쪼개서 관리할까 고민했지만, 우선은 mock 데이터를 랜더링하는 파일도 있어 api 연결 후 필요없는 파일을 삭제해보고 가독성이 떨어지면 섹션 별로 나눠서 폴더로 관리해볼까 생각중입니다!!)  

## ✅ 체크리스트

- [x] 기능 동작 확인
- [ ] 코드 리뷰 반영
- [ ] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->
