### PR TITLE
[Y26W2-263] fix(web): SENTRY_AUTH_TOKEN 전달 수정

### DIFF
--- a/apps/web/turbo.json
+++ b/apps/web/turbo.json
@@ -2,6 +2,9 @@
   "$schema": "../../node_modules/turbo/schema.json",
   "extends": ["//"],
   "tasks": {
+    "build": {
+      "passThroughEnv": ["SENTRY_AUTH_TOKEN"]
+    },
     "dev": {
       "cache": false,
       "dependsOn": ["@ssok/ui#build"],


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- `SENTRY_AUTH_TOKEN` 환경 변수가 빌드 시에 turborepo에서 제대로 전달되고 있지 않아서 이를 수정했습니다.
- https://turborepo.com/docs/reference/configuration#passthroughenv

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

<img width="2426" height="1354" alt="CleanShot 2025-08-09 at 15 47 23@2x" src="https://github.com/user-attachments/assets/707ccbb0-1053-4e74-bf7b-dc39ab59c9de" />


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * "build" 작업에 SENTRY_AUTH_TOKEN 환경 변수를 전달하도록 설정이 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->