### PR TITLE
[Y26W2-284] feat(api): OpenAPI 갱신, 스키마 수정

### DIFF
--- a/apps/web/src/domains/compare/components/compare-table/check-in-out-cell.tsx
+++ b/apps/web/src/domains/compare/components/compare-table/check-in-out-cell.tsx
@@ -11,8 +11,8 @@ const CheckInOutCell = ({ checkInTime, checkOutTime }: CheckInOutCellProps) => {
   const transform = (time: string) => new Date(`1970-01-01T${time}:00+09:00`);
   return (
     <TableTimeContents
-      checkInAt={transform(checkInTime.checkInTimeFrom)}
-      checkOutAt={transform(checkOutTime.checkInTimeTo)}
+      checkInAt={transform(checkInTime.from)}
+      checkOutAt={transform(checkOutTime.to)}
     />
   );
 };

--- a/apps/web/src/domains/compare/hooks/use-compare-data.ts
+++ b/apps/web/src/domains/compare/hooks/use-compare-data.ts
@@ -37,8 +37,8 @@ const mockCompareData: Accommodation[] = [
         byCar: { distance: "800m", time: "7분" },
       },
     ],
-    checkInTime: { checkInTimeFrom: "15:00", checkInTimeTo: "24:00" },
-    checkOutTime: { checkInTimeFrom: "00:00", checkInTimeTo: "11:00" },
+    checkInTime: { from: "15:00", to: "24:00" },
+    checkOutTime: { from: "00:00", to: "11:00" },
     amenities: [
       {
         type: "무료 와이파이",
@@ -111,8 +111,8 @@ const mockCompareData: Accommodation[] = [
         byFoot: { distance: "300m", time: "3분" },
       },
     ],
-    checkInTime: { checkInTimeFrom: "14:00", checkInTimeTo: "23:00" },
-    checkOutTime: { checkInTimeFrom: "00:00", checkInTimeTo: "10:00" },
+    checkInTime: { from: "14:00", to: "23:00" },
+    checkOutTime: { from: "00:00", to: "10:00" },
     amenities: [
       {
         type: "무료 와이파이",
@@ -178,8 +178,8 @@ const mockCompareData: Accommodation[] = [
         description: "",
       },
     ],
-    checkInTime: { checkInTimeFrom: "15:00", checkInTimeTo: "24:00" },
-    checkOutTime: { checkInTimeFrom: "00:00", checkInTimeTo: "12:00" },
+    checkInTime: { from: "15:00", to: "24:00" },
+    checkOutTime: { from: "00:00", to: "12:00" },
     reviewSummary: "최고급 호텔로 서비스와 시설 모든 면에서 완벽합니다.",
     nearbyTransportation: [
       {
@@ -252,8 +252,8 @@ const mockCompareData: Accommodation[] = [
         description: "",
       },
     ],
-    checkInTime: { checkInTimeFrom: "15:00", checkInTimeTo: "24:00" },
-    checkOutTime: { checkInTimeFrom: "00:00", checkInTimeTo: "11:00" },
+    checkInTime: { from: "15:00", to: "24:00" },
+    checkOutTime: { from: "00:00", to: "11:00" },
     reviewSummary: "가격 대비 괜찮은 편이지만 시설이 다소 오래되었습니다.",
     nearbyTransportation: [
       {

--- a/apps/web/src/domains/compare/utils/check-in-out.ts
+++ b/apps/web/src/domains/compare/utils/check-in-out.ts
@@ -3,5 +3,5 @@ import type { CheckTime } from "@ssok/api/schemas";
 export const isCheckTimeExist = (
   checkTime?: CheckTime,
 ): checkTime is Required<CheckTime> => {
-  return !!checkTime?.checkInTimeFrom && !!checkTime?.checkInTimeTo;
+  return !!checkTime?.from && !!checkTime?.to;
 };

--- a/apps/web/src/domains/list/components/link-input-section/index.tsx
+++ b/apps/web/src/domains/list/components/link-input-section/index.tsx
@@ -57,7 +57,7 @@ const LinkInputSection = ({
     // TODO: boardId와 userId는 추후에 실제 값으로 변경
     mutate(
       {
-        data: { url: data.link, memo: data.memo, boardId: 1, userId: 1 },
+        data: { url: data.link, memo: data.memo, boardId: 1 },
       },
       {
         onSuccess: () => {

--- a/packages/api/src/api/openapi.json
+++ b/packages/api/src/api/openapi.json
@@ -11,14 +11,55 @@
   "tags": [
     { "name": "숙소 API", "description": "숙소 관련 API" },
     { "name": "OAUTH API", "description": "소셜 로그인 API" },
-    { "name": "비교표 API", "description": "비교표 관련 API" }
+    { "name": "비교표 API", "description": "비교표 관련 API" },
+    { "name": "여행 보드 API", "description": "여행 보드 관련 API" }
   ],
   "paths": {
+    "/api/trip-boards/{boardId}": {
+      "put": {
+        "tags": ["여행 보드 API"],
+        "summary": "여행 보드 수정",
+        "description": "기존 여행 보드의 기본 정보(보드 이름, 목적지, 여행 기간)를 수정합니다. JWT 인증을 통해 현재 사용자 정보를 추출하고, 수정된 보드 정보를 반환합니다.",
+        "operationId": "updateTripBoard",
+        "parameters": [
+          {
+            "name": "boardId",
+            "in": "path",
+            "description": "여행 보드 ID",
+            "required": true,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TripBoardUpdateRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardResponseTripBoardUpdateResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [{ "JWT": [] }]
+      }
+    },
     "/api/comparison/{tableId}": {
       "get": {
         "tags": ["비교표 API"],
         "summary": "비교표 조회",
-        "description": "비교표 메타 데이터와 포함된 숙소 정보 리스트를 조회합니다.",
+        "description": "비교표 메타 데이터와 포함된 숙소 정보 리스트를 조회합니다. (Authorization 헤더에 Bearer 토큰 필요)",
         "operationId": "getComparisonTable",
         "parameters": [
           {
@@ -40,12 +81,13 @@
               }
             }
           }
-        }
+        },
+        "security": [{ "JWT": [] }]
       },
       "put": {
         "tags": ["비교표 API"],
         "summary": "비교표 수정",
-        "description": "비교표 메타 데이터와 비교 기준 항목을 수정합니다.",
+        "description": "비교표 메타 데이터(제목)와 숙소 세부 내용, 비교 기준 정렬 순서, 숙소 정렬 순서를 수정합니다. (Authorization 헤더에 Bearer 토큰 필요)",
         "operationId": "updateComparisonTable",
         "parameters": [
           {
@@ -60,7 +102,45 @@
           "content": {
             "application/json": {
               "schema": {
-                "$ref": "#/components/schemas/CreateComparisonTableRequest"
+                "$ref": "#/components/schemas/UpdateComparisonTableRequest"
+              }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardResponseBoolean"
+                }
+              }
+            }
+          }
+        },
+        "security": [{ "JWT": [] }]
+      },
+      "patch": {
+        "tags": ["비교표 API"],
+        "summary": "비교표 숙소 추가",
+        "description": "비교표에 새로운 숙소를 추가합니다. (Authorization 헤더에 Bearer 토큰 필요)",
+        "operationId": "addAccommodationToComparisonTable",
+        "parameters": [
+          {
+            "name": "tableId",
+            "in": "path",
+            "description": "테이블의 ID",
+            "required": true,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/AddAccommodationRequest"
               }
             }
           },
@@ -77,36 +157,119 @@
               }
             }
           }
-        }
-      },
-      "patch": {
-        "tags": ["비교표 API"],
-        "summary": "비교표 숙소 추가",
-        "description": "비교표에 새로운 숙소를 추가합니다.",
-        "operationId": "addAccommodationToComparisonTable",
-        "parameters": [
-          {
-            "name": "tableId",
-            "in": "path",
-            "description": "테이블의 ID",
-            "required": true,
-            "schema": { "type": "integer" }
+        },
+        "security": [{ "JWT": [] }]
+      }
+    },
+    "/api/trip-boards/register": {
+      "post": {
+        "tags": ["여행 보드 API"],
+        "summary": "여행 보드 생성",
+        "description": "새로운 여행 보드를 생성합니다. JWT 인증을 통해 현재 사용자 정보를 추출하고, 생성자는 자동으로 OWNER 역할로 등록되며 고유한 초대 링크가 생성됩니다.",
+        "operationId": "createTripBoard",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/TripBoardCreateRequest"
+              }
+            }
           },
-          {
-            "name": "accommodationId",
-            "in": "query",
-            "description": "숙소 ID",
-            "required": true,
-            "schema": { "type": "integer" }
-          }
-        ],
+          "required": true
+        },
         "responses": {
           "200": {
             "description": "OK",
             "content": {
               "*/*": {
                 "schema": {
-                  "$ref": "#/components/schemas/StandardResponseComparisonTableResponse"
+                  "$ref": "#/components/schemas/StandardResponseTripBoardCreateResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [{ "JWT": [] }]
+      }
+    },
+    "/api/trip-boards/leave/{tripBoardId}": {
+      "post": {
+        "tags": ["여행 보드 API"],
+        "summary": "여행 보드 나가기",
+        "description": "여행 보드에서 나갑니다. OWNER인 경우 가장 먼저 입장한 MEMBER에게 권한이 이양되며, 마지막 참여자인 경우 여행보드가 삭제됩니다. 나가는 사용자는 자신이 생성한 리소스(비교표, 숙소)를 유지하거나 제거할 수 있습니다.",
+        "operationId": "leaveTripBoard",
+        "parameters": [],
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/TripBoardLeaveRequest" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardResponseTripBoardLeaveResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [{ "JWT": [] }]
+      }
+    },
+    "/api/oauth/logout": {
+      "post": {
+        "tags": ["OAUTH API"],
+        "summary": "사용자 로그아웃",
+        "description": "현재 로그인된 사용자의 세션을 종료합니다. 헤더에 있는 access-token 토큰을 블랙리스트에 추가합니다. Redis에서 Refresh Token을 삭제하고 브라우저의 REFRESH_TOKEN 쿠키를 무효화합니다. 로그아웃 후에는 새로운 인증이 필요합니다.",
+        "operationId": "logout",
+        "responses": {
+          "200": {
+            "description": "로그아웃이 성공적으로 완료되었습니다.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardResponseLogoutResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [{ "JWT": [] }]
+      }
+    },
+    "/api/oauth/kakao/token": {
+      "post": {
+        "tags": ["OAUTH API"],
+        "summary": "카카오 OAuth 토큰 교환",
+        "description": "카카오에서 발급받은 인가 코드를 통해 액세스 토큰을 획득하고, 사용자 정보를 조회하여 JWT 토큰을 헤더로 설정합니다. JWT 토큰은 응답 헤더로 전달되며, 응답 바디에는 사용자 정보만 포함됩니다. 인가 코드와 baseUrl은 Query Parameter로 전달해야 합니다. 로그인 성공 후 응답 헤더 access-token, 쿠키 REFRESH_TOKEN 로 각각 액세스 토큰, 리프레시 토큰이 전달됩니다.",
+        "operationId": "exchangeKakaoToken",
+        "parameters": [
+          {
+            "name": "code",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" }
+          },
+          {
+            "name": "baseUrl",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "JWT 토큰이 쿠키로 성공적으로 설정되고, 사용자 정보가 반환됩니다.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardResponseOauthLoginResponse"
                 }
               }
             }
@@ -118,7 +281,7 @@
       "post": {
         "tags": ["비교표 API"],
         "summary": "비교표 생성",
-        "description": "비교표 이름, 숙소 ID 리스트, 비교 기준 항목을 받아서 비교표 메타 데이터를 생성합니다.",
+        "description": "비교표 이름, 숙소 ID 리스트, 비교 기준 항목을 받아서 비교표 메타 데이터를 생성합니다. (Authorization 헤더에 Bearer 토큰 필요)",
         "operationId": "createComparisonTable",
         "requestBody": {
           "content": {
@@ -141,7 +304,8 @@
               }
             }
           }
-        }
+        },
+        "security": [{ "JWT": [] }]
       }
     },
     "/api/accommodations/register": {
@@ -172,18 +336,71 @@
               }
             }
           }
-        }
+        },
+        "security": [{ "JWT": [] }]
       }
     },
-    "/api/oauth/kakao": {
+    "/api/trip-boards/search": {
+      "get": {
+        "tags": ["여행 보드 API"],
+        "summary": "여행 보드 목록 조회",
+        "description": "사용자가 참여한 여행 보드 목록을 페이징으로 조회합니다. JWT 인증을 통해 현재 사용자 정보를 추출하고, 최신순으로 정렬된 결과를 반환합니다.",
+        "operationId": "getTripBoards",
+        "parameters": [
+          {
+            "name": "page",
+            "in": "query",
+            "description": "페이지 번호",
+            "required": true,
+            "schema": { "type": "integer", "minimum": 0 }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "페이지 크기",
+            "required": true,
+            "schema": { "type": "integer", "minimum": 1 }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardResponseTripBoardPageResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [{ "JWT": [] }]
+      }
+    },
+    "/api/oauth/kakao/authorize": {
       "get": {
         "tags": ["OAUTH API"],
-        "summary": "카카오 소셜 로그인 리다이렉션",
-        "description": "클라이언트 요청 시 카카오 OAuth2 인가 페이지로 리다이렉트하고, 인가 완료 시 쿠키에 ACCESS TOKEN 및 REFRESH TOKEN을 발급합니다.",
-        "operationId": "redirectToKakaoAuthorization",
+        "summary": "카카오 OAuth 인가 URL 조회",
+        "description": "카카오 OAuth 인가 페이지 URL을 반환합니다. 클라이언트의 baseUrl을 기반으로 동적으로 redirect_uri를 생성합니다. 프론트엔드에서 이 URL로 리다이렉트하여 사용자 인증을 진행합니다.",
+        "operationId": "getKakaoAuthorizeUrl",
+        "parameters": [
+          {
+            "name": "baseUrl",
+            "in": "query",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
         "responses": {
-          "302": {
-            "description": "카카오 인가 페이지로 리다이렉트됩니다. 인가 성공 시 쿠키에 ACCESS TOKEN과 REFRESH TOKEN이 설정됩니다."
+          "200": {
+            "description": "카카오 OAuth 인가 URL이 성공적으로 반환됩니다.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardResponseAuthorizeUrlResponse"
+                }
+              }
+            }
           }
         }
       }
@@ -201,6 +418,26 @@
               "*/*": {
                 "schema": {
                   "$ref": "#/components/schemas/StandardResponseComparisonFactorList"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/comparison/amenity": {
+      "get": {
+        "tags": ["비교표 API"],
+        "summary": "편의 서비스 Enum 리스트",
+        "description": "편의 서비스 항목 Enum 리스트를 반환합니다.",
+        "operationId": "getAmenityFactorList",
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardResponseAmenityFactorList"
                 }
               }
             }
@@ -234,7 +471,8 @@
               }
             }
           }
-        }
+        },
+        "security": [{ "JWT": [] }]
       }
     },
     "/api/accommodations/search": {
@@ -291,7 +529,8 @@
               }
             }
           }
-        }
+        },
+        "security": [{ "JWT": [] }]
       }
     },
     "/api/accommodations/count": {
@@ -327,17 +566,173 @@
               }
             }
           }
-        }
+        },
+        "security": [{ "JWT": [] }]
+      }
+    },
+    "/api/trip-boards/{tripBoardId}": {
+      "delete": {
+        "tags": ["여행 보드 API"],
+        "summary": "여행 보드 삭제",
+        "description": "여행 보드와 관련된 모든 데이터를 삭제합니다. 오직 여행 보드의 소유자(OWNER)만이 삭제할 수 있으며, 삭제 시 해당 보드에 연관된 모든 리소스(숙소 정보, 멤버 매핑 관계, 비교표 등)가 함께 제거됩니다.",
+        "operationId": "deleteTripBoard",
+        "parameters": [
+          {
+            "name": "tripBoardId",
+            "in": "path",
+            "description": "여행 보드 ID",
+            "required": true,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardResponseTripBoardDeleteResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [{ "JWT": [] }]
       }
     }
   },
   "components": {
     "schemas": {
-      "CreateComparisonTableRequest": {
+      "TripBoardUpdateRequest": {
+        "type": "object",
+        "properties": {
+          "boardName": { "type": "string", "maxLength": 20, "minLength": 0 },
+          "destination": {
+            "type": "string",
+            "maxLength": 20,
+            "minLength": 0,
+            "pattern": "^[가-힣a-zA-Z\\s]+$"
+          },
+          "startDate": { "type": "string", "format": "date" },
+          "endDate": { "type": "string", "format": "date" }
+        },
+        "required": ["endDate", "startDate"]
+      },
+      "StandardResponseTripBoardUpdateResponse": {
+        "type": "object",
+        "description": "API 응답의 표준 형식을 정의하는 클래스",
+        "properties": {
+          "responseType": {
+            "type": "string",
+            "description": "응답 유형",
+            "enum": ["SUCCESS", "ERROR"],
+            "example": "SUCCESS"
+          },
+          "result": {
+            "$ref": "#/components/schemas/TripBoardUpdateResponse",
+            "description": "응답 결과 데이터"
+          }
+        }
+      },
+      "TripBoardUpdateResponse": {
+        "type": "object",
+        "properties": {
+          "tripBoardId": { "type": "integer", "format": "int64" },
+          "boardName": { "type": "string" },
+          "destination": { "type": "string" },
+          "startDate": { "type": "string", "format": "date" },
+          "endDate": { "type": "string", "format": "date" },
+          "updatedAt": { "type": "string", "format": "date-time" }
+        }
+      },
+      "AmenityUpdate": {
+        "type": "object",
+        "properties": {
+          "type": { "type": "string" },
+          "available": { "type": "boolean" },
+          "description": { "type": "string" }
+        },
+        "required": ["type"]
+      },
+      "AttractionUpdate": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "type": { "type": "string" },
+          "distance": { "type": "string" },
+          "latitude": { "type": "number", "format": "double" },
+          "longitude": { "type": "number", "format": "double" },
+          "byFoot": { "$ref": "#/components/schemas/DistanceInfo" },
+          "byCar": { "$ref": "#/components/schemas/DistanceInfo" }
+        }
+      },
+      "CheckTimeUpdate": {
+        "type": "object",
+        "properties": {
+          "from": { "type": "string" },
+          "to": { "type": "string" }
+        }
+      },
+      "DistanceInfo": {
+        "type": "object",
+        "properties": {
+          "distance": { "type": "string" },
+          "time": { "type": "string" }
+        }
+      },
+      "TransportationUpdate": {
+        "type": "object",
+        "properties": {
+          "name": { "type": "string" },
+          "type": { "type": "string" },
+          "distance": { "type": "string" },
+          "latitude": { "type": "number", "format": "double" },
+          "longitude": { "type": "number", "format": "double" },
+          "byFoot": { "$ref": "#/components/schemas/DistanceInfo" },
+          "byCar": { "$ref": "#/components/schemas/DistanceInfo" }
+        }
+      },
+      "UpdateAccommodationRequest": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "format": "int64" },
+          "memo": { "type": "string", "maxLength": 100, "minLength": 0 },
+          "lowestPrice": { "type": "integer", "format": "int32" },
+          "currency": { "type": "string" },
+          "reviewScore": { "type": "number", "format": "double" },
+          "cleanlinessScore": { "type": "number", "format": "double" },
+          "reviewSummary": {
+            "type": "string",
+            "maxLength": 100,
+            "minLength": 0
+          },
+          "nearbyAttractions": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/AttractionUpdate" }
+          },
+          "nearbyTransportation": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/TransportationUpdate" }
+          },
+          "amenities": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/AmenityUpdate" }
+          },
+          "checkInTime": { "$ref": "#/components/schemas/CheckTimeUpdate" },
+          "checkOutTime": { "$ref": "#/components/schemas/CheckTimeUpdate" }
+        }
+      },
+      "UpdateComparisonTableRequest": {
         "type": "object",
         "properties": {
           "boardId": { "type": "integer", "format": "int64" },
           "tableName": { "type": "string", "minLength": 1 },
+          "accommodationRequestList": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/UpdateAccommodationRequest"
+            }
+          },
           "accommodationIdList": {
             "type": "array",
             "items": { "type": "integer", "format": "int64" },
@@ -349,7 +744,230 @@
             "minItems": 1
           }
         },
+        "required": ["accommodationRequestList", "boardId"]
+      },
+      "StandardResponseBoolean": {
+        "type": "object",
+        "description": "API 응답의 표준 형식을 정의하는 클래스",
+        "properties": {
+          "responseType": {
+            "type": "string",
+            "description": "응답 유형",
+            "enum": ["SUCCESS", "ERROR"],
+            "example": "SUCCESS"
+          },
+          "result": { "type": "boolean", "description": "응답 결과 데이터" }
+        }
+      },
+      "TripBoardCreateRequest": {
+        "type": "object",
+        "properties": {
+          "boardName": { "type": "string", "maxLength": 20, "minLength": 0 },
+          "destination": {
+            "type": "string",
+            "maxLength": 20,
+            "minLength": 0,
+            "pattern": "^[가-힣a-zA-Z\\s]+$"
+          },
+          "startDate": { "type": "string", "format": "date" },
+          "endDate": { "type": "string", "format": "date" }
+        },
+        "required": ["endDate", "startDate"]
+      },
+      "StandardResponseTripBoardCreateResponse": {
+        "type": "object",
+        "description": "API 응답의 표준 형식을 정의하는 클래스",
+        "properties": {
+          "responseType": {
+            "type": "string",
+            "description": "응답 유형",
+            "enum": ["SUCCESS", "ERROR"],
+            "example": "SUCCESS"
+          },
+          "result": {
+            "$ref": "#/components/schemas/TripBoardCreateResponse",
+            "description": "응답 결과 데이터"
+          }
+        }
+      },
+      "TripBoardCreateResponse": {
+        "type": "object",
+        "properties": {
+          "boardId": { "type": "integer", "format": "int64" },
+          "boardName": { "type": "string" },
+          "destination": { "type": "string" },
+          "travelPeriod": { "type": "string" },
+          "startDate": { "type": "string" },
+          "endDate": { "type": "string" },
+          "invitationUrl": { "type": "string" },
+          "invitationActive": { "type": "boolean" },
+          "creator": { "$ref": "#/components/schemas/UserInfo" },
+          "createdAt": { "type": "string", "format": "date-time" }
+        }
+      },
+      "UserInfo": {
+        "type": "object",
+        "properties": {
+          "id": { "type": "integer", "format": "int64" },
+          "nickname": { "type": "string" },
+          "email": { "type": "string" },
+          "profileImage": { "type": "string" }
+        }
+      },
+      "TripBoardLeaveRequest": {
+        "type": "object",
+        "properties": { "removeResources": { "type": "boolean" } },
+        "required": ["removeResources"]
+      },
+      "StandardResponseTripBoardLeaveResponse": {
+        "type": "object",
+        "description": "API 응답의 표준 형식을 정의하는 클래스",
+        "properties": {
+          "responseType": {
+            "type": "string",
+            "description": "응답 유형",
+            "enum": ["SUCCESS", "ERROR"],
+            "example": "SUCCESS"
+          },
+          "result": {
+            "$ref": "#/components/schemas/TripBoardLeaveResponse",
+            "description": "응답 결과 데이터"
+          }
+        }
+      },
+      "TripBoardLeaveResponse": {
+        "type": "object",
+        "properties": {
+          "tripBoardId": { "type": "integer", "format": "int64" },
+          "leftAt": { "type": "string", "format": "date-time" }
+        }
+      },
+      "LogoutResponse": {
+        "type": "object",
+        "properties": { "logout": { "type": "boolean" } }
+      },
+      "StandardResponseLogoutResponse": {
+        "type": "object",
+        "description": "API 응답의 표준 형식을 정의하는 클래스",
+        "properties": {
+          "responseType": {
+            "type": "string",
+            "description": "응답 유형",
+            "enum": ["SUCCESS", "ERROR"],
+            "example": "SUCCESS"
+          },
+          "result": {
+            "$ref": "#/components/schemas/LogoutResponse",
+            "description": "응답 결과 데이터"
+          }
+        }
+      },
+      "OauthLoginResponse": {
+        "type": "object",
+        "description": "OAuth 로그인 응답",
+        "properties": {
+          "userId": { "type": "integer", "format": "int64" },
+          "nickname": { "type": "string" },
+          "token": { "$ref": "#/components/schemas/TokenSuccessResponse" }
+        }
+      },
+      "StandardResponseOauthLoginResponse": {
+        "type": "object",
+        "description": "API 응답의 표준 형식을 정의하는 클래스",
+        "properties": {
+          "responseType": {
+            "type": "string",
+            "description": "응답 유형",
+            "enum": ["SUCCESS", "ERROR"],
+            "example": "SUCCESS"
+          },
+          "result": {
+            "$ref": "#/components/schemas/OauthLoginResponse",
+            "description": "응답 결과 데이터"
+          }
+        }
+      },
+      "TokenSuccessResponse": {
+        "type": "object",
+        "properties": {
+          "accessToken": { "type": "string" },
+          "refreshToken": { "type": "string" }
+        }
+      },
+      "CreateComparisonTableRequest": {
+        "type": "object",
+        "properties": {
+          "boardId": { "type": "integer", "format": "int64" },
+          "tableName": { "type": "string", "minLength": 1 },
+          "accommodationIdList": {
+            "type": "array",
+            "items": { "type": "integer", "format": "int64" },
+            "minItems": 1
+          },
+          "factorList": { "type": "array", "items": { "type": "string" } }
+        },
         "required": ["boardId"]
+      },
+      "CreateComparisonTableResponse": {
+        "type": "object",
+        "properties": { "tableId": { "type": "integer", "format": "int64" } }
+      },
+      "StandardResponseCreateComparisonTableResponse": {
+        "type": "object",
+        "description": "API 응답의 표준 형식을 정의하는 클래스",
+        "properties": {
+          "responseType": {
+            "type": "string",
+            "description": "응답 유형",
+            "enum": ["SUCCESS", "ERROR"],
+            "example": "SUCCESS"
+          },
+          "result": {
+            "$ref": "#/components/schemas/CreateComparisonTableResponse",
+            "description": "응답 결과 데이터"
+          }
+        }
+      },
+      "AccommodationRegisterRequest": {
+        "type": "object",
+        "properties": {
+          "url": { "type": "string", "minLength": 1 },
+          "memo": { "type": "string", "maxLength": 50, "minLength": 0 },
+          "boardId": { "type": "integer", "format": "int64" }
+        },
+        "required": ["boardId"]
+      },
+      "AccommodationRegisterResponse": {
+        "type": "object",
+        "properties": {
+          "accommodationId": { "type": "integer", "format": "int64" }
+        }
+      },
+      "StandardResponseAccommodationRegisterResponse": {
+        "type": "object",
+        "description": "API 응답의 표준 형식을 정의하는 클래스",
+        "properties": {
+          "responseType": {
+            "type": "string",
+            "description": "응답 유형",
+            "enum": ["SUCCESS", "ERROR"],
+            "example": "SUCCESS"
+          },
+          "result": {
+            "$ref": "#/components/schemas/AccommodationRegisterResponse",
+            "description": "응답 결과 데이터"
+          }
+        }
+      },
+      "AddAccommodationRequest": {
+        "type": "object",
+        "properties": {
+          "accommodationIds": {
+            "type": "array",
+            "items": { "type": "integer", "format": "int64" }
+          }
+        },
+        "required": ["accommodationIds"]
       },
       "AccommodationResponse": {
         "type": "object",
@@ -414,10 +1032,8 @@
       "CheckTime": {
         "type": "object",
         "properties": {
-          "checkInTimeFrom": { "type": "string" },
-          "checkInTimeTo": { "type": "string" },
-          "checkOutTimeFrom": { "type": "string" },
-          "checkOutTimeTo": { "type": "string" }
+          "from": { "type": "string" },
+          "to": { "type": "string" }
         }
       },
       "ComparisonTableResponse": {
@@ -434,29 +1050,18 @@
             "items": {
               "type": "string",
               "enum": [
-                "PARKING",
-                "BREAKFAST",
-                "FREE_WIFI",
-                "POOL",
-                "FITNESS",
-                "LUGGAGE_STORAGE",
-                "BAR_LOUNGE",
-                "FRONT_DESK_HOURS",
-                "PET_FRIENDLY",
-                "BUSINESS_SERVICES",
-                "CLEANING_SERVICE",
-                "HANDICAP_FACILITIES"
+                "REVIEW_SCORE",
+                "ATTRACTION",
+                "TRANSPORTATION",
+                "CLEANLINESS",
+                "AMENITY",
+                "CHECK_TIME",
+                "REVIEW_SUMMARY",
+                "MEMO"
               ]
             }
           },
           "createdBy": { "type": "integer", "format": "int64" }
-        }
-      },
-      "DistanceInfo": {
-        "type": "object",
-        "properties": {
-          "distance": { "type": "string" },
-          "time": { "type": "string" }
         }
       },
       "StandardResponseComparisonTableResponse": {
@@ -487,11 +1092,16 @@
           "byCar": { "$ref": "#/components/schemas/DistanceInfo" }
         }
       },
-      "CreateComparisonTableResponse": {
+      "ParticipantProfileResponse": {
         "type": "object",
-        "properties": { "tableId": { "type": "integer", "format": "int64" } }
+        "properties": {
+          "userId": { "type": "integer", "format": "int64" },
+          "profileImageUrl": { "type": "string" },
+          "nickname": { "type": "string" },
+          "role": { "type": "string", "enum": ["OWNER", "MEMBER"] }
+        }
       },
-      "StandardResponseCreateComparisonTableResponse": {
+      "StandardResponseTripBoardPageResponse": {
         "type": "object",
         "description": "API 응답의 표준 형식을 정의하는 클래스",
         "properties": {
@@ -502,28 +1112,54 @@
             "example": "SUCCESS"
           },
           "result": {
-            "$ref": "#/components/schemas/CreateComparisonTableResponse",
+            "$ref": "#/components/schemas/TripBoardPageResponse",
             "description": "응답 결과 데이터"
           }
         }
       },
-      "AccommodationRegisterRequest": {
+      "TripBoardPageResponse": {
         "type": "object",
         "properties": {
-          "url": { "type": "string", "minLength": 1 },
-          "memo": { "type": "string", "maxLength": 50, "minLength": 0 },
-          "boardId": { "type": "integer", "format": "int64" },
-          "userId": { "type": "integer", "format": "int64" }
-        },
-        "required": ["boardId", "userId"]
-      },
-      "AccommodationRegisterResponse": {
-        "type": "object",
-        "properties": {
-          "accommodationId": { "type": "integer", "format": "int64" }
+          "tripBoards": {
+            "type": "array",
+            "items": { "$ref": "#/components/schemas/TripBoardSummaryResponse" }
+          },
+          "hasNext": { "type": "boolean" }
         }
       },
-      "StandardResponseAccommodationRegisterResponse": {
+      "TripBoardSummaryResponse": {
+        "type": "object",
+        "properties": {
+          "boardId": { "type": "integer", "format": "int64" },
+          "boardName": { "type": "string" },
+          "destination": { "type": "string" },
+          "startDate": { "type": "string", "format": "date" },
+          "endDate": { "type": "string", "format": "date" },
+          "travelPeriod": { "type": "string" },
+          "userRole": { "type": "string", "enum": ["OWNER", "MEMBER"] },
+          "participantCount": { "type": "integer", "format": "int32" },
+          "participants": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ParticipantProfileResponse"
+            }
+          },
+          "createdAt": { "type": "string", "format": "date-time" },
+          "updatedAt": { "type": "string", "format": "date-time" }
+        }
+      },
+      "AuthorizeUrlResponse": {
+        "type": "object",
+        "description": "OAuth 인가 URL 응답",
+        "properties": {
+          "authorizeUrl": {
+            "type": "string",
+            "description": "카카오 OAuth 인가 URL",
+            "example": "https://kauth.kakao.com/oauth/authorize?client_id=..."
+          }
+        }
+      },
+      "StandardResponseAuthorizeUrlResponse": {
         "type": "object",
         "description": "API 응답의 표준 형식을 정의하는 클래스",
         "properties": {
@@ -534,12 +1170,49 @@
             "example": "SUCCESS"
           },
           "result": {
-            "$ref": "#/components/schemas/AccommodationRegisterResponse",
+            "$ref": "#/components/schemas/AuthorizeUrlResponse",
             "description": "응답 결과 데이터"
           }
         }
       },
       "ComparisonFactorList": {
+        "type": "object",
+        "properties": {
+          "factors": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "REVIEW_SCORE",
+                "ATTRACTION",
+                "TRANSPORTATION",
+                "CLEANLINESS",
+                "AMENITY",
+                "CHECK_TIME",
+                "REVIEW_SUMMARY",
+                "MEMO"
+              ]
+            }
+          }
+        }
+      },
+      "StandardResponseComparisonFactorList": {
+        "type": "object",
+        "description": "API 응답의 표준 형식을 정의하는 클래스",
+        "properties": {
+          "responseType": {
+            "type": "string",
+            "description": "응답 유형",
+            "enum": ["SUCCESS", "ERROR"],
+            "example": "SUCCESS"
+          },
+          "result": {
+            "$ref": "#/components/schemas/ComparisonFactorList",
+            "description": "응답 결과 데이터"
+          }
+        }
+      },
+      "AmenityFactorList": {
         "type": "object",
         "properties": {
           "factors": {
@@ -564,7 +1237,7 @@
           }
         }
       },
-      "StandardResponseComparisonFactorList": {
+      "StandardResponseAmenityFactorList": {
         "type": "object",
         "description": "API 응답의 표준 형식을 정의하는 클래스",
         "properties": {
@@ -575,7 +1248,7 @@
             "example": "SUCCESS"
           },
           "result": {
-            "$ref": "#/components/schemas/ComparisonFactorList",
+            "$ref": "#/components/schemas/AmenityFactorList",
             "description": "응답 결과 데이터"
           }
         }
@@ -643,6 +1316,36 @@
             "description": "응답 결과 데이터"
           }
         }
+      },
+      "StandardResponseTripBoardDeleteResponse": {
+        "type": "object",
+        "description": "API 응답의 표준 형식을 정의하는 클래스",
+        "properties": {
+          "responseType": {
+            "type": "string",
+            "description": "응답 유형",
+            "enum": ["SUCCESS", "ERROR"],
+            "example": "SUCCESS"
+          },
+          "result": {
+            "$ref": "#/components/schemas/TripBoardDeleteResponse",
+            "description": "응답 결과 데이터"
+          }
+        }
+      },
+      "TripBoardDeleteResponse": {
+        "type": "object",
+        "properties": {
+          "tripBoardId": { "type": "integer", "format": "int64" }
+        }
+      }
+    },
+    "securitySchemes": {
+      "JWT": {
+        "type": "http",
+        "description": "JWT Access Token을 Authorization 헤더로 전송",
+        "scheme": "bearer",
+        "bearerFormat": "JWT"
       }
     }
   }

--- a/packages/api/src/api/transformer.js
+++ b/packages/api/src/api/transformer.js
@@ -1,7 +1,35 @@
 /**
- * @param {import("openapi3-ts/oas31").OpenAPIObject} schema
+ * @param {import("./openapi.json")} spec
  * @return {import("openapi3-ts/oas31").OpenAPIObject}
  */
 export default (spec) => {
+  // FIX: deleteTripBoard
+  spec.paths["/api/trip-boards/{boardId}"].delete =
+    spec.paths["/api/trip-boards/{tripBoardId}"].delete;
+  spec.paths["/api/trip-boards/{boardId}"].delete.parameters = [
+    {
+      name: "boardId",
+      in: "path",
+      description: "여행 보드 ID",
+      required: true,
+      schema: { type: "integer" },
+    },
+  ];
+  delete spec.paths["/api/trip-boards/{tripBoardId}"];
+
+  // FIX: leaveTripBoard
+  spec.paths["/api/trip-boards/leave/{boardId}"] =
+    spec.paths["/api/trip-boards/leave/{tripBoardId}"];
+  spec.paths["/api/trip-boards/leave/{boardId}"].post.parameters = [
+    {
+      name: "boardId",
+      in: "path",
+      description: "여행 보드 ID",
+      required: true,
+      schema: { type: "integer" },
+    },
+  ];
+  delete spec.paths["/api/trip-boards/leave/{tripBoardId}"];
+
   return spec;
 };

--- a/packages/api/src/index.msw.ts
+++ b/packages/api/src/index.msw.ts
@@ -14,10 +14,86 @@ import type {
   StandardResponseAccommodationPageResponse,
   StandardResponseAccommodationRegisterResponse,
   StandardResponseAccommodationResponse,
+  StandardResponseAmenityFactorList,
+  StandardResponseAuthorizeUrlResponse,
+  StandardResponseBoolean,
   StandardResponseComparisonFactorList,
   StandardResponseComparisonTableResponse,
   StandardResponseCreateComparisonTableResponse,
+  StandardResponseLogoutResponse,
+  StandardResponseOauthLoginResponse,
+  StandardResponseTripBoardCreateResponse,
+  StandardResponseTripBoardDeleteResponse,
+  StandardResponseTripBoardLeaveResponse,
+  StandardResponseTripBoardPageResponse,
+  StandardResponseTripBoardUpdateResponse,
 } from "./index.schemas";
+
+export const getUpdateTripBoardResponseMock = (
+  overrideResponse: Partial<StandardResponseTripBoardUpdateResponse> = {},
+): StandardResponseTripBoardUpdateResponse => ({
+  responseType: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(["SUCCESS", "ERROR"] as const),
+    undefined,
+  ]),
+  result: faker.helpers.arrayElement([
+    {
+      tripBoardId: faker.helpers.arrayElement([
+        faker.number.int({
+          min: undefined,
+          max: undefined,
+          multipleOf: undefined,
+        }),
+        undefined,
+      ]),
+      boardName: faker.helpers.arrayElement([
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
+        undefined,
+      ]),
+      destination: faker.helpers.arrayElement([
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
+        undefined,
+      ]),
+      startDate: faker.helpers.arrayElement([
+        new Date(faker.date.past().toISOString().split("T")[0]),
+        undefined,
+      ]),
+      endDate: faker.helpers.arrayElement([
+        new Date(faker.date.past().toISOString().split("T")[0]),
+        undefined,
+      ]),
+      updatedAt: faker.helpers.arrayElement([
+        new Date(`${faker.date.past().toISOString().split(".")[0]}Z`),
+        undefined,
+      ]),
+    },
+    undefined,
+  ]),
+  ...overrideResponse,
+});
+
+export const getDeleteTripBoardResponseMock = (
+  overrideResponse: Partial<StandardResponseTripBoardDeleteResponse> = {},
+): StandardResponseTripBoardDeleteResponse => ({
+  responseType: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(["SUCCESS", "ERROR"] as const),
+    undefined,
+  ]),
+  result: faker.helpers.arrayElement([
+    {
+      tripBoardId: faker.helpers.arrayElement([
+        faker.number.int({
+          min: undefined,
+          max: undefined,
+          multipleOf: undefined,
+        }),
+        undefined,
+      ]),
+    },
+    undefined,
+  ]),
+  ...overrideResponse,
+});
 
 export const getGetComparisonTableResponseMock = (
   overrideResponse: Partial<StandardResponseComparisonTableResponse> = {},
@@ -318,19 +394,11 @@ export const getGetComparisonTableResponseMock = (
           ]),
           checkInTime: faker.helpers.arrayElement([
             {
-              checkInTimeFrom: faker.helpers.arrayElement([
+              from: faker.helpers.arrayElement([
                 faker.string.alpha({ length: { min: 10, max: 20 } }),
                 undefined,
               ]),
-              checkInTimeTo: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              checkOutTimeFrom: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              checkOutTimeTo: faker.helpers.arrayElement([
+              to: faker.helpers.arrayElement([
                 faker.string.alpha({ length: { min: 10, max: 20 } }),
                 undefined,
               ]),
@@ -339,19 +407,11 @@ export const getGetComparisonTableResponseMock = (
           ]),
           checkOutTime: faker.helpers.arrayElement([
             {
-              checkInTimeFrom: faker.helpers.arrayElement([
+              from: faker.helpers.arrayElement([
                 faker.string.alpha({ length: { min: 10, max: 20 } }),
                 undefined,
               ]),
-              checkInTimeTo: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              checkOutTimeFrom: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              checkOutTimeTo: faker.helpers.arrayElement([
+              to: faker.helpers.arrayElement([
                 faker.string.alpha({ length: { min: 10, max: 20 } }),
                 undefined,
               ]),
@@ -363,18 +423,14 @@ export const getGetComparisonTableResponseMock = (
       ]),
       factorsList: faker.helpers.arrayElement([
         faker.helpers.arrayElements([
-          "PARKING",
-          "BREAKFAST",
-          "FREE_WIFI",
-          "POOL",
-          "FITNESS",
-          "LUGGAGE_STORAGE",
-          "BAR_LOUNGE",
-          "FRONT_DESK_HOURS",
-          "PET_FRIENDLY",
-          "BUSINESS_SERVICES",
-          "CLEANING_SERVICE",
-          "HANDICAP_FACILITIES",
+          "REVIEW_SCORE",
+          "ATTRACTION",
+          "TRANSPORTATION",
+          "CLEANLINESS",
+          "AMENITY",
+          "CHECK_TIME",
+          "REVIEW_SUMMARY",
+          "MEMO",
         ] as const),
         undefined,
       ]),
@@ -393,375 +449,13 @@ export const getGetComparisonTableResponseMock = (
 });
 
 export const getUpdateComparisonTableResponseMock = (
-  overrideResponse: Partial<StandardResponseComparisonTableResponse> = {},
-): StandardResponseComparisonTableResponse => ({
+  overrideResponse: Partial<StandardResponseBoolean> = {},
+): StandardResponseBoolean => ({
   responseType: faker.helpers.arrayElement([
     faker.helpers.arrayElement(["SUCCESS", "ERROR"] as const),
     undefined,
   ]),
-  result: faker.helpers.arrayElement([
-    {
-      tableId: faker.helpers.arrayElement([
-        faker.number.int({
-          min: undefined,
-          max: undefined,
-          multipleOf: undefined,
-        }),
-        undefined,
-      ]),
-      tableName: faker.helpers.arrayElement([
-        faker.string.alpha({ length: { min: 10, max: 20 } }),
-        undefined,
-      ]),
-      accommodationResponsesList: faker.helpers.arrayElement([
-        Array.from(
-          { length: faker.number.int({ min: 4, max: 4 }) },
-          (_, i) => i + 1,
-        ).map(() => ({
-          id: faker.helpers.arrayElement([
-            faker.number.int({
-              min: undefined,
-              max: undefined,
-              multipleOf: undefined,
-            }),
-            undefined,
-          ]),
-          url: faker.helpers.arrayElement([
-            faker.string.alpha({ length: { min: 10, max: 20 } }),
-            undefined,
-          ]),
-          siteName: faker.helpers.arrayElement([
-            faker.string.alpha({ length: { min: 10, max: 20 } }),
-            undefined,
-          ]),
-          logoUrl: faker.helpers.arrayElement([
-            faker.string.alpha({ length: { min: 10, max: 20 } }),
-            undefined,
-          ]),
-          memo: faker.helpers.arrayElement([
-            faker.string.alpha({ length: { min: 10, max: 20 } }),
-            undefined,
-          ]),
-          createdAt: faker.helpers.arrayElement([
-            new Date(`${faker.date.past().toISOString().split(".")[0]}Z`),
-            undefined,
-          ]),
-          updatedAt: faker.helpers.arrayElement([
-            new Date(`${faker.date.past().toISOString().split(".")[0]}Z`),
-            undefined,
-          ]),
-          createdBy: faker.helpers.arrayElement([
-            faker.number.int({
-              min: undefined,
-              max: undefined,
-              multipleOf: undefined,
-            }),
-            undefined,
-          ]),
-          boardId: faker.helpers.arrayElement([
-            faker.number.int({
-              min: undefined,
-              max: undefined,
-              multipleOf: undefined,
-            }),
-            undefined,
-          ]),
-          accommodationName: faker.helpers.arrayElement([
-            faker.string.alpha({ length: { min: 10, max: 20 } }),
-            undefined,
-          ]),
-          images: faker.helpers.arrayElement([
-            Array.from(
-              { length: faker.number.int({ min: 4, max: 4 }) },
-              (_, i) => i + 1,
-            ).map(() => faker.string.alpha({ length: { min: 10, max: 20 } })),
-            undefined,
-          ]),
-          address: faker.helpers.arrayElement([
-            faker.string.alpha({ length: { min: 10, max: 20 } }),
-            undefined,
-          ]),
-          latitude: faker.helpers.arrayElement([
-            faker.number.float({
-              min: undefined,
-              max: undefined,
-              fractionDigits: 2,
-            }),
-            undefined,
-          ]),
-          longitude: faker.helpers.arrayElement([
-            faker.number.float({
-              min: undefined,
-              max: undefined,
-              fractionDigits: 2,
-            }),
-            undefined,
-          ]),
-          lowestPrice: faker.helpers.arrayElement([
-            faker.number.int({
-              min: undefined,
-              max: undefined,
-              multipleOf: undefined,
-            }),
-            undefined,
-          ]),
-          highestPrice: faker.helpers.arrayElement([
-            faker.number.int({
-              min: undefined,
-              max: undefined,
-              multipleOf: undefined,
-            }),
-            undefined,
-          ]),
-          currency: faker.helpers.arrayElement([
-            faker.string.alpha({ length: { min: 10, max: 20 } }),
-            undefined,
-          ]),
-          reviewScore: faker.helpers.arrayElement([
-            faker.number.float({
-              min: undefined,
-              max: undefined,
-              fractionDigits: 2,
-            }),
-            undefined,
-          ]),
-          cleanlinessScore: faker.helpers.arrayElement([
-            faker.number.float({
-              min: undefined,
-              max: undefined,
-              fractionDigits: 2,
-            }),
-            undefined,
-          ]),
-          reviewSummary: faker.helpers.arrayElement([
-            faker.string.alpha({ length: { min: 10, max: 20 } }),
-            undefined,
-          ]),
-          hotelId: faker.helpers.arrayElement([
-            faker.number.int({
-              min: undefined,
-              max: undefined,
-              multipleOf: undefined,
-            }),
-            undefined,
-          ]),
-          nearbyAttractions: faker.helpers.arrayElement([
-            Array.from(
-              { length: faker.number.int({ min: 4, max: 4 }) },
-              (_, i) => i + 1,
-            ).map(() => ({
-              name: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              type: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              latitude: faker.helpers.arrayElement([
-                faker.number.float({
-                  min: undefined,
-                  max: undefined,
-                  fractionDigits: 2,
-                }),
-                undefined,
-              ]),
-              longitude: faker.helpers.arrayElement([
-                faker.number.float({
-                  min: undefined,
-                  max: undefined,
-                  fractionDigits: 2,
-                }),
-                undefined,
-              ]),
-              distance: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              byFoot: faker.helpers.arrayElement([
-                {
-                  distance: faker.helpers.arrayElement([
-                    faker.string.alpha({ length: { min: 10, max: 20 } }),
-                    undefined,
-                  ]),
-                  time: faker.helpers.arrayElement([
-                    faker.string.alpha({ length: { min: 10, max: 20 } }),
-                    undefined,
-                  ]),
-                },
-                undefined,
-              ]),
-              byCar: faker.helpers.arrayElement([
-                {
-                  distance: faker.helpers.arrayElement([
-                    faker.string.alpha({ length: { min: 10, max: 20 } }),
-                    undefined,
-                  ]),
-                  time: faker.helpers.arrayElement([
-                    faker.string.alpha({ length: { min: 10, max: 20 } }),
-                    undefined,
-                  ]),
-                },
-                undefined,
-              ]),
-            })),
-            undefined,
-          ]),
-          nearbyTransportation: faker.helpers.arrayElement([
-            Array.from(
-              { length: faker.number.int({ min: 4, max: 4 }) },
-              (_, i) => i + 1,
-            ).map(() => ({
-              name: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              type: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              latitude: faker.helpers.arrayElement([
-                faker.number.float({
-                  min: undefined,
-                  max: undefined,
-                  fractionDigits: 2,
-                }),
-                undefined,
-              ]),
-              longitude: faker.helpers.arrayElement([
-                faker.number.float({
-                  min: undefined,
-                  max: undefined,
-                  fractionDigits: 2,
-                }),
-                undefined,
-              ]),
-              distance: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              byFoot: faker.helpers.arrayElement([
-                {
-                  distance: faker.helpers.arrayElement([
-                    faker.string.alpha({ length: { min: 10, max: 20 } }),
-                    undefined,
-                  ]),
-                  time: faker.helpers.arrayElement([
-                    faker.string.alpha({ length: { min: 10, max: 20 } }),
-                    undefined,
-                  ]),
-                },
-                undefined,
-              ]),
-              byCar: faker.helpers.arrayElement([
-                {
-                  distance: faker.helpers.arrayElement([
-                    faker.string.alpha({ length: { min: 10, max: 20 } }),
-                    undefined,
-                  ]),
-                  time: faker.helpers.arrayElement([
-                    faker.string.alpha({ length: { min: 10, max: 20 } }),
-                    undefined,
-                  ]),
-                },
-                undefined,
-              ]),
-            })),
-            undefined,
-          ]),
-          amenities: faker.helpers.arrayElement([
-            Array.from(
-              { length: faker.number.int({ min: 4, max: 4 }) },
-              (_, i) => i + 1,
-            ).map(() => ({
-              type: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              available: faker.helpers.arrayElement([
-                faker.datatype.boolean(),
-                undefined,
-              ]),
-              description: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-            })),
-            undefined,
-          ]),
-          checkInTime: faker.helpers.arrayElement([
-            {
-              checkInTimeFrom: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              checkInTimeTo: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              checkOutTimeFrom: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              checkOutTimeTo: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-            },
-            undefined,
-          ]),
-          checkOutTime: faker.helpers.arrayElement([
-            {
-              checkInTimeFrom: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              checkInTimeTo: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              checkOutTimeFrom: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              checkOutTimeTo: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-            },
-            undefined,
-          ]),
-        })),
-        undefined,
-      ]),
-      factorsList: faker.helpers.arrayElement([
-        faker.helpers.arrayElements([
-          "PARKING",
-          "BREAKFAST",
-          "FREE_WIFI",
-          "POOL",
-          "FITNESS",
-          "LUGGAGE_STORAGE",
-          "BAR_LOUNGE",
-          "FRONT_DESK_HOURS",
-          "PET_FRIENDLY",
-          "BUSINESS_SERVICES",
-          "CLEANING_SERVICE",
-          "HANDICAP_FACILITIES",
-        ] as const),
-        undefined,
-      ]),
-      createdBy: faker.helpers.arrayElement([
-        faker.number.int({
-          min: undefined,
-          max: undefined,
-          multipleOf: undefined,
-        }),
-        undefined,
-      ]),
-    },
-    undefined,
-  ]),
+  result: faker.helpers.arrayElement([faker.datatype.boolean(), undefined]),
   ...overrideResponse,
 });
 
@@ -1064,19 +758,11 @@ export const getAddAccommodationToComparisonTableResponseMock = (
           ]),
           checkInTime: faker.helpers.arrayElement([
             {
-              checkInTimeFrom: faker.helpers.arrayElement([
+              from: faker.helpers.arrayElement([
                 faker.string.alpha({ length: { min: 10, max: 20 } }),
                 undefined,
               ]),
-              checkInTimeTo: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              checkOutTimeFrom: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              checkOutTimeTo: faker.helpers.arrayElement([
+              to: faker.helpers.arrayElement([
                 faker.string.alpha({ length: { min: 10, max: 20 } }),
                 undefined,
               ]),
@@ -1085,19 +771,11 @@ export const getAddAccommodationToComparisonTableResponseMock = (
           ]),
           checkOutTime: faker.helpers.arrayElement([
             {
-              checkInTimeFrom: faker.helpers.arrayElement([
+              from: faker.helpers.arrayElement([
                 faker.string.alpha({ length: { min: 10, max: 20 } }),
                 undefined,
               ]),
-              checkInTimeTo: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              checkOutTimeFrom: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              checkOutTimeTo: faker.helpers.arrayElement([
+              to: faker.helpers.arrayElement([
                 faker.string.alpha({ length: { min: 10, max: 20 } }),
                 undefined,
               ]),
@@ -1109,18 +787,14 @@ export const getAddAccommodationToComparisonTableResponseMock = (
       ]),
       factorsList: faker.helpers.arrayElement([
         faker.helpers.arrayElements([
-          "PARKING",
-          "BREAKFAST",
-          "FREE_WIFI",
-          "POOL",
-          "FITNESS",
-          "LUGGAGE_STORAGE",
-          "BAR_LOUNGE",
-          "FRONT_DESK_HOURS",
-          "PET_FRIENDLY",
-          "BUSINESS_SERVICES",
-          "CLEANING_SERVICE",
-          "HANDICAP_FACILITIES",
+          "REVIEW_SCORE",
+          "ATTRACTION",
+          "TRANSPORTATION",
+          "CLEANLINESS",
+          "AMENITY",
+          "CHECK_TIME",
+          "REVIEW_SUMMARY",
+          "MEMO",
         ] as const),
         undefined,
       ]),
@@ -1130,6 +804,142 @@ export const getAddAccommodationToComparisonTableResponseMock = (
           max: undefined,
           multipleOf: undefined,
         }),
+        undefined,
+      ]),
+    },
+    undefined,
+  ]),
+  ...overrideResponse,
+});
+
+export const getCreateTripBoardResponseMock = (
+  overrideResponse: Partial<StandardResponseTripBoardCreateResponse> = {},
+): StandardResponseTripBoardCreateResponse => ({
+  responseType: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(["SUCCESS", "ERROR"] as const),
+    undefined,
+  ]),
+  result: faker.helpers.arrayElement([
+    {
+      boardId: faker.helpers.arrayElement([
+        faker.number.int({
+          min: undefined,
+          max: undefined,
+          multipleOf: undefined,
+        }),
+        undefined,
+      ]),
+      boardName: faker.helpers.arrayElement([
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
+        undefined,
+      ]),
+      destination: faker.helpers.arrayElement([
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
+        undefined,
+      ]),
+      travelPeriod: faker.helpers.arrayElement([
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
+        undefined,
+      ]),
+      startDate: faker.helpers.arrayElement([
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
+        undefined,
+      ]),
+      endDate: faker.helpers.arrayElement([
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
+        undefined,
+      ]),
+      invitationUrl: faker.helpers.arrayElement([
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
+        undefined,
+      ]),
+      invitationActive: faker.helpers.arrayElement([
+        faker.datatype.boolean(),
+        undefined,
+      ]),
+      creator: faker.helpers.arrayElement([
+        {
+          id: faker.helpers.arrayElement([
+            faker.number.int({
+              min: undefined,
+              max: undefined,
+              multipleOf: undefined,
+            }),
+            undefined,
+          ]),
+          nickname: faker.helpers.arrayElement([
+            faker.string.alpha({ length: { min: 10, max: 20 } }),
+            undefined,
+          ]),
+          email: faker.helpers.arrayElement([
+            faker.string.alpha({ length: { min: 10, max: 20 } }),
+            undefined,
+          ]),
+          profileImage: faker.helpers.arrayElement([
+            faker.string.alpha({ length: { min: 10, max: 20 } }),
+            undefined,
+          ]),
+        },
+        undefined,
+      ]),
+      createdAt: faker.helpers.arrayElement([
+        new Date(`${faker.date.past().toISOString().split(".")[0]}Z`),
+        undefined,
+      ]),
+    },
+    undefined,
+  ]),
+  ...overrideResponse,
+});
+
+export const getLogoutResponseMock = (
+  overrideResponse: Partial<StandardResponseLogoutResponse> = {},
+): StandardResponseLogoutResponse => ({
+  responseType: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(["SUCCESS", "ERROR"] as const),
+    undefined,
+  ]),
+  result: faker.helpers.arrayElement([
+    {
+      logout: faker.helpers.arrayElement([faker.datatype.boolean(), undefined]),
+    },
+    undefined,
+  ]),
+  ...overrideResponse,
+});
+
+export const getExchangeKakaoTokenResponseMock = (
+  overrideResponse: Partial<StandardResponseOauthLoginResponse> = {},
+): StandardResponseOauthLoginResponse => ({
+  responseType: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(["SUCCESS", "ERROR"] as const),
+    undefined,
+  ]),
+  result: faker.helpers.arrayElement([
+    {
+      userId: faker.helpers.arrayElement([
+        faker.number.int({
+          min: undefined,
+          max: undefined,
+          multipleOf: undefined,
+        }),
+        undefined,
+      ]),
+      nickname: faker.helpers.arrayElement([
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
+        undefined,
+      ]),
+      token: faker.helpers.arrayElement([
+        {
+          accessToken: faker.helpers.arrayElement([
+            faker.string.alpha({ length: { min: 10, max: 20 } }),
+            undefined,
+          ]),
+          refreshToken: faker.helpers.arrayElement([
+            faker.string.alpha({ length: { min: 10, max: 20 } }),
+            undefined,
+          ]),
+        },
         undefined,
       ]),
     },
@@ -1184,9 +994,159 @@ export const getRegisterAccommodationCardResponseMock = (
   ...overrideResponse,
 });
 
+export const getGetTripBoardsResponseMock = (
+  overrideResponse: Partial<StandardResponseTripBoardPageResponse> = {},
+): StandardResponseTripBoardPageResponse => ({
+  responseType: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(["SUCCESS", "ERROR"] as const),
+    undefined,
+  ]),
+  result: faker.helpers.arrayElement([
+    {
+      tripBoards: faker.helpers.arrayElement([
+        Array.from(
+          { length: faker.number.int({ min: 4, max: 4 }) },
+          (_, i) => i + 1,
+        ).map(() => ({
+          boardId: faker.helpers.arrayElement([
+            faker.number.int({
+              min: undefined,
+              max: undefined,
+              multipleOf: undefined,
+            }),
+            undefined,
+          ]),
+          boardName: faker.helpers.arrayElement([
+            faker.string.alpha({ length: { min: 10, max: 20 } }),
+            undefined,
+          ]),
+          destination: faker.helpers.arrayElement([
+            faker.string.alpha({ length: { min: 10, max: 20 } }),
+            undefined,
+          ]),
+          startDate: faker.helpers.arrayElement([
+            new Date(faker.date.past().toISOString().split("T")[0]),
+            undefined,
+          ]),
+          endDate: faker.helpers.arrayElement([
+            new Date(faker.date.past().toISOString().split("T")[0]),
+            undefined,
+          ]),
+          travelPeriod: faker.helpers.arrayElement([
+            faker.string.alpha({ length: { min: 10, max: 20 } }),
+            undefined,
+          ]),
+          userRole: faker.helpers.arrayElement([
+            faker.helpers.arrayElement(["OWNER", "MEMBER"] as const),
+            undefined,
+          ]),
+          participantCount: faker.helpers.arrayElement([
+            faker.number.int({
+              min: undefined,
+              max: undefined,
+              multipleOf: undefined,
+            }),
+            undefined,
+          ]),
+          participants: faker.helpers.arrayElement([
+            Array.from(
+              { length: faker.number.int({ min: 4, max: 4 }) },
+              (_, i) => i + 1,
+            ).map(() => ({
+              userId: faker.helpers.arrayElement([
+                faker.number.int({
+                  min: undefined,
+                  max: undefined,
+                  multipleOf: undefined,
+                }),
+                undefined,
+              ]),
+              profileImageUrl: faker.helpers.arrayElement([
+                faker.string.alpha({ length: { min: 10, max: 20 } }),
+                undefined,
+              ]),
+              nickname: faker.helpers.arrayElement([
+                faker.string.alpha({ length: { min: 10, max: 20 } }),
+                undefined,
+              ]),
+              role: faker.helpers.arrayElement([
+                faker.helpers.arrayElement(["OWNER", "MEMBER"] as const),
+                undefined,
+              ]),
+            })),
+            undefined,
+          ]),
+          createdAt: faker.helpers.arrayElement([
+            new Date(`${faker.date.past().toISOString().split(".")[0]}Z`),
+            undefined,
+          ]),
+          updatedAt: faker.helpers.arrayElement([
+            new Date(`${faker.date.past().toISOString().split(".")[0]}Z`),
+            undefined,
+          ]),
+        })),
+        undefined,
+      ]),
+      hasNext: faker.helpers.arrayElement([
+        faker.datatype.boolean(),
+        undefined,
+      ]),
+    },
+    undefined,
+  ]),
+  ...overrideResponse,
+});
+
+export const getGetKakaoAuthorizeUrlResponseMock = (
+  overrideResponse: Partial<StandardResponseAuthorizeUrlResponse> = {},
+): StandardResponseAuthorizeUrlResponse => ({
+  responseType: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(["SUCCESS", "ERROR"] as const),
+    undefined,
+  ]),
+  result: faker.helpers.arrayElement([
+    {
+      authorizeUrl: faker.helpers.arrayElement([
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
+        undefined,
+      ]),
+    },
+    undefined,
+  ]),
+  ...overrideResponse,
+});
+
 export const getGetComparisonFactorListResponseMock = (
   overrideResponse: Partial<StandardResponseComparisonFactorList> = {},
 ): StandardResponseComparisonFactorList => ({
+  responseType: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(["SUCCESS", "ERROR"] as const),
+    undefined,
+  ]),
+  result: faker.helpers.arrayElement([
+    {
+      factors: faker.helpers.arrayElement([
+        faker.helpers.arrayElements([
+          "REVIEW_SCORE",
+          "ATTRACTION",
+          "TRANSPORTATION",
+          "CLEANLINESS",
+          "AMENITY",
+          "CHECK_TIME",
+          "REVIEW_SUMMARY",
+          "MEMO",
+        ] as const),
+        undefined,
+      ]),
+    },
+    undefined,
+  ]),
+  ...overrideResponse,
+});
+
+export const getGetAmenityFactorListResponseMock = (
+  overrideResponse: Partial<StandardResponseAmenityFactorList> = {},
+): StandardResponseAmenityFactorList => ({
   responseType: faker.helpers.arrayElement([
     faker.helpers.arrayElement(["SUCCESS", "ERROR"] as const),
     undefined,
@@ -1498,19 +1458,11 @@ export const getGetAccommodationByIdResponseMock = (
       ]),
       checkInTime: faker.helpers.arrayElement([
         {
-          checkInTimeFrom: faker.helpers.arrayElement([
+          from: faker.helpers.arrayElement([
             faker.string.alpha({ length: { min: 10, max: 20 } }),
             undefined,
           ]),
-          checkInTimeTo: faker.helpers.arrayElement([
-            faker.string.alpha({ length: { min: 10, max: 20 } }),
-            undefined,
-          ]),
-          checkOutTimeFrom: faker.helpers.arrayElement([
-            faker.string.alpha({ length: { min: 10, max: 20 } }),
-            undefined,
-          ]),
-          checkOutTimeTo: faker.helpers.arrayElement([
+          to: faker.helpers.arrayElement([
             faker.string.alpha({ length: { min: 10, max: 20 } }),
             undefined,
           ]),
@@ -1519,19 +1471,11 @@ export const getGetAccommodationByIdResponseMock = (
       ]),
       checkOutTime: faker.helpers.arrayElement([
         {
-          checkInTimeFrom: faker.helpers.arrayElement([
+          from: faker.helpers.arrayElement([
             faker.string.alpha({ length: { min: 10, max: 20 } }),
             undefined,
           ]),
-          checkInTimeTo: faker.helpers.arrayElement([
-            faker.string.alpha({ length: { min: 10, max: 20 } }),
-            undefined,
-          ]),
-          checkOutTimeFrom: faker.helpers.arrayElement([
-            faker.string.alpha({ length: { min: 10, max: 20 } }),
-            undefined,
-          ]),
-          checkOutTimeTo: faker.helpers.arrayElement([
+          to: faker.helpers.arrayElement([
             faker.string.alpha({ length: { min: 10, max: 20 } }),
             undefined,
           ]),
@@ -1831,19 +1775,11 @@ export const getGetAccommodationByBoardIdAndUserIdResponseMock = (
           ]),
           checkInTime: faker.helpers.arrayElement([
             {
-              checkInTimeFrom: faker.helpers.arrayElement([
+              from: faker.helpers.arrayElement([
                 faker.string.alpha({ length: { min: 10, max: 20 } }),
                 undefined,
               ]),
-              checkInTimeTo: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              checkOutTimeFrom: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              checkOutTimeTo: faker.helpers.arrayElement([
+              to: faker.helpers.arrayElement([
                 faker.string.alpha({ length: { min: 10, max: 20 } }),
                 undefined,
               ]),
@@ -1852,19 +1788,11 @@ export const getGetAccommodationByBoardIdAndUserIdResponseMock = (
           ]),
           checkOutTime: faker.helpers.arrayElement([
             {
-              checkInTimeFrom: faker.helpers.arrayElement([
+              from: faker.helpers.arrayElement([
                 faker.string.alpha({ length: { min: 10, max: 20 } }),
                 undefined,
               ]),
-              checkInTimeTo: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              checkOutTimeFrom: faker.helpers.arrayElement([
-                faker.string.alpha({ length: { min: 10, max: 20 } }),
-                undefined,
-              ]),
-              checkOutTimeTo: faker.helpers.arrayElement([
+              to: faker.helpers.arrayElement([
                 faker.string.alpha({ length: { min: 10, max: 20 } }),
                 undefined,
               ]),
@@ -1907,6 +1835,83 @@ export const getGetAccommodationCountByBoardIdResponseMock = (
   ...overrideResponse,
 });
 
+export const getLeaveTripBoardResponseMock = (
+  overrideResponse: Partial<StandardResponseTripBoardLeaveResponse> = {},
+): StandardResponseTripBoardLeaveResponse => ({
+  responseType: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(["SUCCESS", "ERROR"] as const),
+    undefined,
+  ]),
+  result: faker.helpers.arrayElement([
+    {
+      tripBoardId: faker.helpers.arrayElement([
+        faker.number.int({
+          min: undefined,
+          max: undefined,
+          multipleOf: undefined,
+        }),
+        undefined,
+      ]),
+      leftAt: faker.helpers.arrayElement([
+        new Date(`${faker.date.past().toISOString().split(".")[0]}Z`),
+        undefined,
+      ]),
+    },
+    undefined,
+  ]),
+  ...overrideResponse,
+});
+
+export const getUpdateTripBoardMockHandler = (
+  overrideResponse?:
+    | StandardResponseTripBoardUpdateResponse
+    | ((
+        info: Parameters<Parameters<typeof http.put>[1]>[0],
+      ) =>
+        | Promise<StandardResponseTripBoardUpdateResponse>
+        | StandardResponseTripBoardUpdateResponse),
+) => {
+  return http.put("*/api/trip-boards/:boardId", async (info) => {
+    await delay(500);
+
+    return new HttpResponse(
+      JSON.stringify(
+        overrideResponse !== undefined
+          ? typeof overrideResponse === "function"
+            ? await overrideResponse(info)
+            : overrideResponse
+          : getUpdateTripBoardResponseMock(),
+      ),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+};
+
+export const getDeleteTripBoardMockHandler = (
+  overrideResponse?:
+    | StandardResponseTripBoardDeleteResponse
+    | ((
+        info: Parameters<Parameters<typeof http.delete>[1]>[0],
+      ) =>
+        | Promise<StandardResponseTripBoardDeleteResponse>
+        | StandardResponseTripBoardDeleteResponse),
+) => {
+  return http.delete("*/api/trip-boards/:boardId", async (info) => {
+    await delay(500);
+
+    return new HttpResponse(
+      JSON.stringify(
+        overrideResponse !== undefined
+          ? typeof overrideResponse === "function"
+            ? await overrideResponse(info)
+            : overrideResponse
+          : getDeleteTripBoardResponseMock(),
+      ),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+};
+
 export const getGetComparisonTableMockHandler = (
   overrideResponse?:
     | StandardResponseComparisonTableResponse
@@ -1934,12 +1939,10 @@ export const getGetComparisonTableMockHandler = (
 
 export const getUpdateComparisonTableMockHandler = (
   overrideResponse?:
-    | StandardResponseComparisonTableResponse
+    | StandardResponseBoolean
     | ((
         info: Parameters<Parameters<typeof http.put>[1]>[0],
-      ) =>
-        | Promise<StandardResponseComparisonTableResponse>
-        | StandardResponseComparisonTableResponse),
+      ) => Promise<StandardResponseBoolean> | StandardResponseBoolean),
 ) => {
   return http.put("*/api/comparison/:tableId", async (info) => {
     await delay(500);
@@ -1976,6 +1979,81 @@ export const getAddAccommodationToComparisonTableMockHandler = (
             ? await overrideResponse(info)
             : overrideResponse
           : getAddAccommodationToComparisonTableResponseMock(),
+      ),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+};
+
+export const getCreateTripBoardMockHandler = (
+  overrideResponse?:
+    | StandardResponseTripBoardCreateResponse
+    | ((
+        info: Parameters<Parameters<typeof http.post>[1]>[0],
+      ) =>
+        | Promise<StandardResponseTripBoardCreateResponse>
+        | StandardResponseTripBoardCreateResponse),
+) => {
+  return http.post("*/api/trip-boards/register", async (info) => {
+    await delay(500);
+
+    return new HttpResponse(
+      JSON.stringify(
+        overrideResponse !== undefined
+          ? typeof overrideResponse === "function"
+            ? await overrideResponse(info)
+            : overrideResponse
+          : getCreateTripBoardResponseMock(),
+      ),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+};
+
+export const getLogoutMockHandler = (
+  overrideResponse?:
+    | StandardResponseLogoutResponse
+    | ((
+        info: Parameters<Parameters<typeof http.post>[1]>[0],
+      ) =>
+        | Promise<StandardResponseLogoutResponse>
+        | StandardResponseLogoutResponse),
+) => {
+  return http.post("*/api/oauth/logout", async (info) => {
+    await delay(500);
+
+    return new HttpResponse(
+      JSON.stringify(
+        overrideResponse !== undefined
+          ? typeof overrideResponse === "function"
+            ? await overrideResponse(info)
+            : overrideResponse
+          : getLogoutResponseMock(),
+      ),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+};
+
+export const getExchangeKakaoTokenMockHandler = (
+  overrideResponse?:
+    | StandardResponseOauthLoginResponse
+    | ((
+        info: Parameters<Parameters<typeof http.post>[1]>[0],
+      ) =>
+        | Promise<StandardResponseOauthLoginResponse>
+        | StandardResponseOauthLoginResponse),
+) => {
+  return http.post("*/api/oauth/kakao/token", async (info) => {
+    await delay(500);
+
+    return new HttpResponse(
+      JSON.stringify(
+        overrideResponse !== undefined
+          ? typeof overrideResponse === "function"
+            ? await overrideResponse(info)
+            : overrideResponse
+          : getExchangeKakaoTokenResponseMock(),
       ),
       { status: 200, headers: { "Content-Type": "application/json" } },
     );
@@ -2032,19 +2110,53 @@ export const getRegisterAccommodationCardMockHandler = (
   });
 };
 
-export const getRedirectToKakaoAuthorizationMockHandler = (
+export const getGetTripBoardsMockHandler = (
   overrideResponse?:
-    | unknown
+    | StandardResponseTripBoardPageResponse
     | ((
         info: Parameters<Parameters<typeof http.get>[1]>[0],
-      ) => Promise<unknown> | unknown),
+      ) =>
+        | Promise<StandardResponseTripBoardPageResponse>
+        | StandardResponseTripBoardPageResponse),
 ) => {
-  return http.get("*/api/oauth/kakao", async (info) => {
+  return http.get("*/api/trip-boards/search", async (info) => {
     await delay(500);
-    if (typeof overrideResponse === "function") {
-      await overrideResponse(info);
-    }
-    return new HttpResponse(null, { status: 200 });
+
+    return new HttpResponse(
+      JSON.stringify(
+        overrideResponse !== undefined
+          ? typeof overrideResponse === "function"
+            ? await overrideResponse(info)
+            : overrideResponse
+          : getGetTripBoardsResponseMock(),
+      ),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+};
+
+export const getGetKakaoAuthorizeUrlMockHandler = (
+  overrideResponse?:
+    | StandardResponseAuthorizeUrlResponse
+    | ((
+        info: Parameters<Parameters<typeof http.get>[1]>[0],
+      ) =>
+        | Promise<StandardResponseAuthorizeUrlResponse>
+        | StandardResponseAuthorizeUrlResponse),
+) => {
+  return http.get("*/api/oauth/kakao/authorize", async (info) => {
+    await delay(500);
+
+    return new HttpResponse(
+      JSON.stringify(
+        overrideResponse !== undefined
+          ? typeof overrideResponse === "function"
+            ? await overrideResponse(info)
+            : overrideResponse
+          : getGetKakaoAuthorizeUrlResponseMock(),
+      ),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
   });
 };
 
@@ -2067,6 +2179,31 @@ export const getGetComparisonFactorListMockHandler = (
             ? await overrideResponse(info)
             : overrideResponse
           : getGetComparisonFactorListResponseMock(),
+      ),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+};
+
+export const getGetAmenityFactorListMockHandler = (
+  overrideResponse?:
+    | StandardResponseAmenityFactorList
+    | ((
+        info: Parameters<Parameters<typeof http.get>[1]>[0],
+      ) =>
+        | Promise<StandardResponseAmenityFactorList>
+        | StandardResponseAmenityFactorList),
+) => {
+  return http.get("*/api/comparison/amenity", async (info) => {
+    await delay(500);
+
+    return new HttpResponse(
+      JSON.stringify(
+        overrideResponse !== undefined
+          ? typeof overrideResponse === "function"
+            ? await overrideResponse(info)
+            : overrideResponse
+          : getGetAmenityFactorListResponseMock(),
       ),
       { status: 200, headers: { "Content-Type": "application/json" } },
     );
@@ -2147,15 +2284,48 @@ export const getGetAccommodationCountByBoardIdMockHandler = (
     );
   });
 };
+
+export const getLeaveTripBoardMockHandler = (
+  overrideResponse?:
+    | StandardResponseTripBoardLeaveResponse
+    | ((
+        info: Parameters<Parameters<typeof http.post>[1]>[0],
+      ) =>
+        | Promise<StandardResponseTripBoardLeaveResponse>
+        | StandardResponseTripBoardLeaveResponse),
+) => {
+  return http.post("*/api/trip-boards/leave/:boardId", async (info) => {
+    await delay(500);
+
+    return new HttpResponse(
+      JSON.stringify(
+        overrideResponse !== undefined
+          ? typeof overrideResponse === "function"
+            ? await overrideResponse(info)
+            : overrideResponse
+          : getLeaveTripBoardResponseMock(),
+      ),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+};
 export const getYapp26Web2Mock = () => [
+  getUpdateTripBoardMockHandler(),
+  getDeleteTripBoardMockHandler(),
   getGetComparisonTableMockHandler(),
   getUpdateComparisonTableMockHandler(),
   getAddAccommodationToComparisonTableMockHandler(),
+  getCreateTripBoardMockHandler(),
+  getLogoutMockHandler(),
+  getExchangeKakaoTokenMockHandler(),
   getCreateComparisonTableMockHandler(),
   getRegisterAccommodationCardMockHandler(),
-  getRedirectToKakaoAuthorizationMockHandler(),
+  getGetTripBoardsMockHandler(),
+  getGetKakaoAuthorizeUrlMockHandler(),
   getGetComparisonFactorListMockHandler(),
+  getGetAmenityFactorListMockHandler(),
   getGetAccommodationByIdMockHandler(),
   getGetAccommodationByBoardIdAndUserIdMockHandler(),
   getGetAccommodationCountByBoardIdMockHandler(),
+  getLeaveTripBoardMockHandler(),
 ];

--- a/packages/api/src/index.schemas.ts
+++ b/packages/api/src/index.schemas.ts
@@ -5,14 +5,318 @@
  * SSOK 서비스 API 명세
  * OpenAPI spec version: v1
  */
+export interface TripBoardUpdateRequest {
+  /**
+   * @minLength 0
+   * @maxLength 20
+   */
+  boardName?: string;
+  /**
+   * @minLength 0
+   * @maxLength 20
+   * @pattern ^[가-힣a-zA-Z\s]+$
+   */
+  destination?: string;
+  startDate: Date;
+  endDate: Date;
+}
+
+/**
+ * 응답 유형
+ */
+export type StandardResponseTripBoardUpdateResponseResponseType =
+  | "SUCCESS"
+  | "ERROR";
+/**
+ * API 응답의 표준 형식을 정의하는 클래스
+ */
+export interface StandardResponseTripBoardUpdateResponse {
+  /** 응답 유형 */
+  responseType?: StandardResponseTripBoardUpdateResponseResponseType;
+  /** 응답 결과 데이터 */
+  result?: TripBoardUpdateResponse;
+}
+
+export interface TripBoardUpdateResponse {
+  tripBoardId?: number;
+  boardName?: string;
+  destination?: string;
+  startDate?: Date;
+  endDate?: Date;
+  updatedAt?: Date;
+}
+
+export interface AmenityUpdate {
+  type: string;
+  available?: boolean;
+  description?: string;
+}
+
+export interface AttractionUpdate {
+  name?: string;
+  type?: string;
+  distance?: string;
+  latitude?: number;
+  longitude?: number;
+  byFoot?: DistanceInfo;
+  byCar?: DistanceInfo;
+}
+
+export interface CheckTimeUpdate {
+  from?: string;
+  to?: string;
+}
+
+export interface DistanceInfo {
+  distance?: string;
+  time?: string;
+}
+
+export interface TransportationUpdate {
+  name?: string;
+  type?: string;
+  distance?: string;
+  latitude?: number;
+  longitude?: number;
+  byFoot?: DistanceInfo;
+  byCar?: DistanceInfo;
+}
+
+export interface UpdateAccommodationRequest {
+  id?: number;
+  /**
+   * @minLength 0
+   * @maxLength 100
+   */
+  memo?: string;
+  lowestPrice?: number;
+  currency?: string;
+  reviewScore?: number;
+  cleanlinessScore?: number;
+  /**
+   * @minLength 0
+   * @maxLength 100
+   */
+  reviewSummary?: string;
+  nearbyAttractions?: AttractionUpdate[];
+  nearbyTransportation?: TransportationUpdate[];
+  amenities?: AmenityUpdate[];
+  checkInTime?: CheckTimeUpdate;
+  checkOutTime?: CheckTimeUpdate;
+}
+
+export interface UpdateComparisonTableRequest {
+  boardId: number;
+  /** @minLength 1 */
+  tableName?: string;
+  accommodationRequestList: UpdateAccommodationRequest[];
+  /** @minItems 1 */
+  accommodationIdList?: number[];
+  /** @minItems 1 */
+  factorList?: string[];
+}
+
+/**
+ * 응답 유형
+ */
+export type StandardResponseBooleanResponseType = "SUCCESS" | "ERROR";
+/**
+ * API 응답의 표준 형식을 정의하는 클래스
+ */
+export interface StandardResponseBoolean {
+  /** 응답 유형 */
+  responseType?: StandardResponseBooleanResponseType;
+  /** 응답 결과 데이터 */
+  result?: boolean;
+}
+
+export interface TripBoardCreateRequest {
+  /**
+   * @minLength 0
+   * @maxLength 20
+   */
+  boardName?: string;
+  /**
+   * @minLength 0
+   * @maxLength 20
+   * @pattern ^[가-힣a-zA-Z\s]+$
+   */
+  destination?: string;
+  startDate: Date;
+  endDate: Date;
+}
+
+/**
+ * 응답 유형
+ */
+export type StandardResponseTripBoardCreateResponseResponseType =
+  | "SUCCESS"
+  | "ERROR";
+/**
+ * API 응답의 표준 형식을 정의하는 클래스
+ */
+export interface StandardResponseTripBoardCreateResponse {
+  /** 응답 유형 */
+  responseType?: StandardResponseTripBoardCreateResponseResponseType;
+  /** 응답 결과 데이터 */
+  result?: TripBoardCreateResponse;
+}
+
+export interface TripBoardCreateResponse {
+  boardId?: number;
+  boardName?: string;
+  destination?: string;
+  travelPeriod?: string;
+  startDate?: string;
+  endDate?: string;
+  invitationUrl?: string;
+  invitationActive?: boolean;
+  creator?: UserInfo;
+  createdAt?: Date;
+}
+
+export interface UserInfo {
+  id?: number;
+  nickname?: string;
+  email?: string;
+  profileImage?: string;
+}
+
+export interface TripBoardLeaveRequest {
+  removeResources: boolean;
+}
+
+/**
+ * 응답 유형
+ */
+export type StandardResponseTripBoardLeaveResponseResponseType =
+  | "SUCCESS"
+  | "ERROR";
+/**
+ * API 응답의 표준 형식을 정의하는 클래스
+ */
+export interface StandardResponseTripBoardLeaveResponse {
+  /** 응답 유형 */
+  responseType?: StandardResponseTripBoardLeaveResponseResponseType;
+  /** 응답 결과 데이터 */
+  result?: TripBoardLeaveResponse;
+}
+
+export interface TripBoardLeaveResponse {
+  tripBoardId?: number;
+  leftAt?: Date;
+}
+
+export interface LogoutResponse {
+  logout?: boolean;
+}
+
+/**
+ * 응답 유형
+ */
+export type StandardResponseLogoutResponseResponseType = "SUCCESS" | "ERROR";
+/**
+ * API 응답의 표준 형식을 정의하는 클래스
+ */
+export interface StandardResponseLogoutResponse {
+  /** 응답 유형 */
+  responseType?: StandardResponseLogoutResponseResponseType;
+  /** 응답 결과 데이터 */
+  result?: LogoutResponse;
+}
+
+/**
+ * OAuth 로그인 응답
+ */
+export interface OauthLoginResponse {
+  userId?: number;
+  nickname?: string;
+  token?: TokenSuccessResponse;
+}
+
+/**
+ * 응답 유형
+ */
+export type StandardResponseOauthLoginResponseResponseType =
+  | "SUCCESS"
+  | "ERROR";
+/**
+ * API 응답의 표준 형식을 정의하는 클래스
+ */
+export interface StandardResponseOauthLoginResponse {
+  /** 응답 유형 */
+  responseType?: StandardResponseOauthLoginResponseResponseType;
+  /** 응답 결과 데이터 */
+  result?: OauthLoginResponse;
+}
+
+export interface TokenSuccessResponse {
+  accessToken?: string;
+  refreshToken?: string;
+}
+
 export interface CreateComparisonTableRequest {
   boardId: number;
   /** @minLength 1 */
   tableName?: string;
   /** @minItems 1 */
   accommodationIdList?: number[];
-  /** @minItems 1 */
   factorList?: string[];
+}
+
+export interface CreateComparisonTableResponse {
+  tableId?: number;
+}
+
+/**
+ * 응답 유형
+ */
+export type StandardResponseCreateComparisonTableResponseResponseType =
+  | "SUCCESS"
+  | "ERROR";
+/**
+ * API 응답의 표준 형식을 정의하는 클래스
+ */
+export interface StandardResponseCreateComparisonTableResponse {
+  /** 응답 유형 */
+  responseType?: StandardResponseCreateComparisonTableResponseResponseType;
+  /** 응답 결과 데이터 */
+  result?: CreateComparisonTableResponse;
+}
+
+export interface AccommodationRegisterRequest {
+  /** @minLength 1 */
+  url?: string;
+  /**
+   * @minLength 0
+   * @maxLength 50
+   */
+  memo?: string;
+  boardId: number;
+}
+
+export interface AccommodationRegisterResponse {
+  accommodationId?: number;
+}
+
+/**
+ * 응답 유형
+ */
+export type StandardResponseAccommodationRegisterResponseResponseType =
+  | "SUCCESS"
+  | "ERROR";
+/**
+ * API 응답의 표준 형식을 정의하는 클래스
+ */
+export interface StandardResponseAccommodationRegisterResponse {
+  /** 응답 유형 */
+  responseType?: StandardResponseAccommodationRegisterResponseResponseType;
+  /** 응답 결과 데이터 */
+  result?: AccommodationRegisterResponse;
+}
+
+export interface AddAccommodationRequest {
+  accommodationIds: number[];
 }
 
 export interface AccommodationResponse {
@@ -61,36 +365,25 @@ export interface Attraction {
 }
 
 export interface CheckTime {
-  checkInTimeFrom?: string;
-  checkInTimeTo?: string;
-  checkOutTimeFrom?: string;
-  checkOutTimeTo?: string;
+  from?: string;
+  to?: string;
 }
 
 export type ComparisonTableResponseFactorsListItem =
-  | "PARKING"
-  | "BREAKFAST"
-  | "FREE_WIFI"
-  | "POOL"
-  | "FITNESS"
-  | "LUGGAGE_STORAGE"
-  | "BAR_LOUNGE"
-  | "FRONT_DESK_HOURS"
-  | "PET_FRIENDLY"
-  | "BUSINESS_SERVICES"
-  | "CLEANING_SERVICE"
-  | "HANDICAP_FACILITIES";
+  | "REVIEW_SCORE"
+  | "ATTRACTION"
+  | "TRANSPORTATION"
+  | "CLEANLINESS"
+  | "AMENITY"
+  | "CHECK_TIME"
+  | "REVIEW_SUMMARY"
+  | "MEMO";
 export interface ComparisonTableResponse {
   tableId?: number;
   tableName?: string;
   accommodationResponsesList?: AccommodationResponse[];
   factorsList?: ComparisonTableResponseFactorsListItem[];
   createdBy?: number;
-}
-
-export interface DistanceInfo {
-  distance?: string;
-  time?: string;
 }
 
 /**
@@ -119,71 +412,83 @@ export interface Transportation {
   byCar?: DistanceInfo;
 }
 
-export interface CreateComparisonTableResponse {
-  tableId?: number;
+export type ParticipantProfileResponseRole = "OWNER" | "MEMBER";
+export interface ParticipantProfileResponse {
+  userId?: number;
+  profileImageUrl?: string;
+  nickname?: string;
+  role?: ParticipantProfileResponseRole;
 }
 
 /**
  * 응답 유형
  */
-export type StandardResponseCreateComparisonTableResponseResponseType =
+export type StandardResponseTripBoardPageResponseResponseType =
   | "SUCCESS"
   | "ERROR";
 /**
  * API 응답의 표준 형식을 정의하는 클래스
  */
-export interface StandardResponseCreateComparisonTableResponse {
+export interface StandardResponseTripBoardPageResponse {
   /** 응답 유형 */
-  responseType?: StandardResponseCreateComparisonTableResponseResponseType;
+  responseType?: StandardResponseTripBoardPageResponseResponseType;
   /** 응답 결과 데이터 */
-  result?: CreateComparisonTableResponse;
+  result?: TripBoardPageResponse;
 }
 
-export interface AccommodationRegisterRequest {
-  /** @minLength 1 */
-  url?: string;
-  /**
-   * @minLength 0
-   * @maxLength 50
-   */
-  memo?: string;
-  boardId: number;
-  userId: number;
+export interface TripBoardPageResponse {
+  tripBoards?: TripBoardSummaryResponse[];
+  hasNext?: boolean;
 }
 
-export interface AccommodationRegisterResponse {
-  accommodationId?: number;
+export type TripBoardSummaryResponseUserRole = "OWNER" | "MEMBER";
+export interface TripBoardSummaryResponse {
+  boardId?: number;
+  boardName?: string;
+  destination?: string;
+  startDate?: Date;
+  endDate?: Date;
+  travelPeriod?: string;
+  userRole?: TripBoardSummaryResponseUserRole;
+  participantCount?: number;
+  participants?: ParticipantProfileResponse[];
+  createdAt?: Date;
+  updatedAt?: Date;
+}
+
+/**
+ * OAuth 인가 URL 응답
+ */
+export interface AuthorizeUrlResponse {
+  /** 카카오 OAuth 인가 URL */
+  authorizeUrl?: string;
 }
 
 /**
  * 응답 유형
  */
-export type StandardResponseAccommodationRegisterResponseResponseType =
+export type StandardResponseAuthorizeUrlResponseResponseType =
   | "SUCCESS"
   | "ERROR";
 /**
  * API 응답의 표준 형식을 정의하는 클래스
  */
-export interface StandardResponseAccommodationRegisterResponse {
+export interface StandardResponseAuthorizeUrlResponse {
   /** 응답 유형 */
-  responseType?: StandardResponseAccommodationRegisterResponseResponseType;
+  responseType?: StandardResponseAuthorizeUrlResponseResponseType;
   /** 응답 결과 데이터 */
-  result?: AccommodationRegisterResponse;
+  result?: AuthorizeUrlResponse;
 }
 
 export type ComparisonFactorListFactorsItem =
-  | "PARKING"
-  | "BREAKFAST"
-  | "FREE_WIFI"
-  | "POOL"
-  | "FITNESS"
-  | "LUGGAGE_STORAGE"
-  | "BAR_LOUNGE"
-  | "FRONT_DESK_HOURS"
-  | "PET_FRIENDLY"
-  | "BUSINESS_SERVICES"
-  | "CLEANING_SERVICE"
-  | "HANDICAP_FACILITIES";
+  | "REVIEW_SCORE"
+  | "ATTRACTION"
+  | "TRANSPORTATION"
+  | "CLEANLINESS"
+  | "AMENITY"
+  | "CHECK_TIME"
+  | "REVIEW_SUMMARY"
+  | "MEMO";
 export interface ComparisonFactorList {
   factors?: ComparisonFactorListFactorsItem[];
 }
@@ -202,6 +507,37 @@ export interface StandardResponseComparisonFactorList {
   responseType?: StandardResponseComparisonFactorListResponseType;
   /** 응답 결과 데이터 */
   result?: ComparisonFactorList;
+}
+
+export type AmenityFactorListFactorsItem =
+  | "PARKING"
+  | "BREAKFAST"
+  | "FREE_WIFI"
+  | "POOL"
+  | "FITNESS"
+  | "LUGGAGE_STORAGE"
+  | "BAR_LOUNGE"
+  | "FRONT_DESK_HOURS"
+  | "PET_FRIENDLY"
+  | "BUSINESS_SERVICES"
+  | "CLEANING_SERVICE"
+  | "HANDICAP_FACILITIES";
+export interface AmenityFactorList {
+  factors?: AmenityFactorListFactorsItem[];
+}
+
+/**
+ * 응답 유형
+ */
+export type StandardResponseAmenityFactorListResponseType = "SUCCESS" | "ERROR";
+/**
+ * API 응답의 표준 형식을 정의하는 클래스
+ */
+export interface StandardResponseAmenityFactorList {
+  /** 응답 유형 */
+  responseType?: StandardResponseAmenityFactorListResponseType;
+  /** 응답 결과 데이터 */
+  result?: AmenityFactorList;
 }
 
 /**
@@ -261,11 +597,46 @@ export interface StandardResponseAccommodationCountResponse {
   result?: AccommodationCountResponse;
 }
 
-export type AddAccommodationToComparisonTableParams = {
+/**
+ * 응답 유형
+ */
+export type StandardResponseTripBoardDeleteResponseResponseType =
+  | "SUCCESS"
+  | "ERROR";
+/**
+ * API 응답의 표준 형식을 정의하는 클래스
+ */
+export interface StandardResponseTripBoardDeleteResponse {
+  /** 응답 유형 */
+  responseType?: StandardResponseTripBoardDeleteResponseResponseType;
+  /** 응답 결과 데이터 */
+  result?: TripBoardDeleteResponse;
+}
+
+export interface TripBoardDeleteResponse {
+  tripBoardId?: number;
+}
+
+export type ExchangeKakaoTokenParams = {
+  code: string;
+  baseUrl: string;
+};
+
+export type GetTripBoardsParams = {
   /**
-   * 숙소 ID
+   * 페이지 번호
+   * @minimum 0
    */
-  accommodationId: number;
+  page: number;
+  /**
+   * 페이지 크기
+   * @minimum 1
+   */
+  size: number;
+};
+
+export type GetKakaoAuthorizeUrlParams = {
+  baseUrl: string;
 };
 
 export type GetAccommodationByBoardIdAndUserIdParams = {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -35,23 +35,239 @@ import {
 import { http } from "./api/http";
 import type {
   AccommodationRegisterRequest,
-  AddAccommodationToComparisonTableParams,
+  AddAccommodationRequest,
   CreateComparisonTableRequest,
+  ExchangeKakaoTokenParams,
   GetAccommodationByBoardIdAndUserIdParams,
   GetAccommodationCountByBoardIdParams,
+  GetKakaoAuthorizeUrlParams,
+  GetTripBoardsParams,
   StandardResponseAccommodationCountResponse,
   StandardResponseAccommodationPageResponse,
   StandardResponseAccommodationRegisterResponse,
   StandardResponseAccommodationResponse,
+  StandardResponseAmenityFactorList,
+  StandardResponseAuthorizeUrlResponse,
+  StandardResponseBoolean,
   StandardResponseComparisonFactorList,
   StandardResponseComparisonTableResponse,
   StandardResponseCreateComparisonTableResponse,
+  StandardResponseLogoutResponse,
+  StandardResponseOauthLoginResponse,
+  StandardResponseTripBoardCreateResponse,
+  StandardResponseTripBoardDeleteResponse,
+  StandardResponseTripBoardLeaveResponse,
+  StandardResponseTripBoardPageResponse,
+  StandardResponseTripBoardUpdateResponse,
+  TripBoardCreateRequest,
+  TripBoardLeaveRequest,
+  TripBoardUpdateRequest,
+  UpdateComparisonTableRequest,
 } from "./index.schemas";
 
 type SecondParameter<T extends (...args: never) => unknown> = Parameters<T>[1];
 
 /**
- * 비교표 메타 데이터와 포함된 숙소 정보 리스트를 조회합니다.
+ * 기존 여행 보드의 기본 정보(보드 이름, 목적지, 여행 기간)를 수정합니다. JWT 인증을 통해 현재 사용자 정보를 추출하고, 수정된 보드 정보를 반환합니다.
+ * @summary 여행 보드 수정
+ */
+export type updateTripBoardResponse200 = {
+  data: StandardResponseTripBoardUpdateResponse;
+  status: 200;
+};
+
+export type updateTripBoardResponseComposite = updateTripBoardResponse200;
+
+export type updateTripBoardResponse = updateTripBoardResponseComposite & {
+  headers: Headers;
+};
+
+export const getUpdateTripBoardUrl = (boardId: number) => {
+  return `https://api.ssok.info/api/trip-boards/${boardId}`;
+};
+
+export const updateTripBoard = async (
+  boardId: number,
+  tripBoardUpdateRequest: TripBoardUpdateRequest,
+  options?: RequestInit,
+): Promise<updateTripBoardResponse> => {
+  return http<updateTripBoardResponse>(getUpdateTripBoardUrl(boardId), {
+    ...options,
+    method: "PUT",
+    headers: { "Content-Type": "application/json", ...options?.headers },
+    body: JSON.stringify(tripBoardUpdateRequest),
+  });
+};
+
+export const getUpdateTripBoardMutationOptions = <
+  TError = unknown,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof updateTripBoard>>,
+    TError,
+    { boardId: number; data: TripBoardUpdateRequest },
+    TContext
+  >;
+  request?: SecondParameter<typeof http>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof updateTripBoard>>,
+  TError,
+  { boardId: number; data: TripBoardUpdateRequest },
+  TContext
+> => {
+  const mutationKey = ["updateTripBoard"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      "mutationKey" in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof updateTripBoard>>,
+    { boardId: number; data: TripBoardUpdateRequest }
+  > = (props) => {
+    const { boardId, data } = props ?? {};
+
+    return updateTripBoard(boardId, data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type UpdateTripBoardMutationResult = NonNullable<
+  Awaited<ReturnType<typeof updateTripBoard>>
+>;
+export type UpdateTripBoardMutationBody = TripBoardUpdateRequest;
+export type UpdateTripBoardMutationError = unknown;
+
+/**
+ * @summary 여행 보드 수정
+ */
+export const useUpdateTripBoard = <TError = unknown, TContext = unknown>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof updateTripBoard>>,
+      TError,
+      { boardId: number; data: TripBoardUpdateRequest },
+      TContext
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof updateTripBoard>>,
+  TError,
+  { boardId: number; data: TripBoardUpdateRequest },
+  TContext
+> => {
+  const mutationOptions = getUpdateTripBoardMutationOptions(options);
+
+  return useMutation(mutationOptions, queryClient);
+};
+
+/**
+ * 여행 보드와 관련된 모든 데이터를 삭제합니다. 오직 여행 보드의 소유자(OWNER)만이 삭제할 수 있으며, 삭제 시 해당 보드에 연관된 모든 리소스(숙소 정보, 멤버 매핑 관계, 비교표 등)가 함께 제거됩니다.
+ * @summary 여행 보드 삭제
+ */
+export type deleteTripBoardResponse200 = {
+  data: StandardResponseTripBoardDeleteResponse;
+  status: 200;
+};
+
+export type deleteTripBoardResponseComposite = deleteTripBoardResponse200;
+
+export type deleteTripBoardResponse = deleteTripBoardResponseComposite & {
+  headers: Headers;
+};
+
+export const getDeleteTripBoardUrl = (boardId: number) => {
+  return `https://api.ssok.info/api/trip-boards/${boardId}`;
+};
+
+export const deleteTripBoard = async (
+  boardId: number,
+  options?: RequestInit,
+): Promise<deleteTripBoardResponse> => {
+  return http<deleteTripBoardResponse>(getDeleteTripBoardUrl(boardId), {
+    ...options,
+    method: "DELETE",
+  });
+};
+
+export const getDeleteTripBoardMutationOptions = <
+  TError = unknown,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof deleteTripBoard>>,
+    TError,
+    { boardId: number },
+    TContext
+  >;
+  request?: SecondParameter<typeof http>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof deleteTripBoard>>,
+  TError,
+  { boardId: number },
+  TContext
+> => {
+  const mutationKey = ["deleteTripBoard"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      "mutationKey" in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof deleteTripBoard>>,
+    { boardId: number }
+  > = (props) => {
+    const { boardId } = props ?? {};
+
+    return deleteTripBoard(boardId, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type DeleteTripBoardMutationResult = NonNullable<
+  Awaited<ReturnType<typeof deleteTripBoard>>
+>;
+
+export type DeleteTripBoardMutationError = unknown;
+
+/**
+ * @summary 여행 보드 삭제
+ */
+export const useDeleteTripBoard = <TError = unknown, TContext = unknown>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof deleteTripBoard>>,
+      TError,
+      { boardId: number },
+      TContext
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof deleteTripBoard>>,
+  TError,
+  { boardId: number },
+  TContext
+> => {
+  const mutationOptions = getDeleteTripBoardMutationOptions(options);
+
+  return useMutation(mutationOptions, queryClient);
+};
+
+/**
+ * 비교표 메타 데이터와 포함된 숙소 정보 리스트를 조회합니다. (Authorization 헤더에 Bearer 토큰 필요)
  * @summary 비교표 조회
  */
 export type getComparisonTableResponse200 = {
@@ -391,11 +607,11 @@ export function useGetComparisonTableSuspense<
 }
 
 /**
- * 비교표 메타 데이터와 비교 기준 항목을 수정합니다.
+ * 비교표 메타 데이터(제목)와 숙소 세부 내용, 비교 기준 정렬 순서, 숙소 정렬 순서를 수정합니다. (Authorization 헤더에 Bearer 토큰 필요)
  * @summary 비교표 수정
  */
 export type updateComparisonTableResponse200 = {
-  data: StandardResponseComparisonTableResponse;
+  data: StandardResponseBoolean;
   status: 200;
 };
 
@@ -413,7 +629,7 @@ export const getUpdateComparisonTableUrl = (tableId: number) => {
 
 export const updateComparisonTable = async (
   tableId: number,
-  createComparisonTableRequest: CreateComparisonTableRequest,
+  updateComparisonTableRequest: UpdateComparisonTableRequest,
   options?: RequestInit,
 ): Promise<updateComparisonTableResponse> => {
   return http<updateComparisonTableResponse>(
@@ -422,7 +638,7 @@ export const updateComparisonTable = async (
       ...options,
       method: "PUT",
       headers: { "Content-Type": "application/json", ...options?.headers },
-      body: JSON.stringify(createComparisonTableRequest),
+      body: JSON.stringify(updateComparisonTableRequest),
     },
   );
 };
@@ -434,14 +650,14 @@ export const getUpdateComparisonTableMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof updateComparisonTable>>,
     TError,
-    { tableId: number; data: CreateComparisonTableRequest },
+    { tableId: number; data: UpdateComparisonTableRequest },
     TContext
   >;
   request?: SecondParameter<typeof http>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof updateComparisonTable>>,
   TError,
-  { tableId: number; data: CreateComparisonTableRequest },
+  { tableId: number; data: UpdateComparisonTableRequest },
   TContext
 > => {
   const mutationKey = ["updateComparisonTable"];
@@ -455,7 +671,7 @@ export const getUpdateComparisonTableMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof updateComparisonTable>>,
-    { tableId: number; data: CreateComparisonTableRequest }
+    { tableId: number; data: UpdateComparisonTableRequest }
   > = (props) => {
     const { tableId, data } = props ?? {};
 
@@ -468,7 +684,7 @@ export const getUpdateComparisonTableMutationOptions = <
 export type UpdateComparisonTableMutationResult = NonNullable<
   Awaited<ReturnType<typeof updateComparisonTable>>
 >;
-export type UpdateComparisonTableMutationBody = CreateComparisonTableRequest;
+export type UpdateComparisonTableMutationBody = UpdateComparisonTableRequest;
 export type UpdateComparisonTableMutationError = unknown;
 
 /**
@@ -479,7 +695,7 @@ export const useUpdateComparisonTable = <TError = unknown, TContext = unknown>(
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof updateComparisonTable>>,
       TError,
-      { tableId: number; data: CreateComparisonTableRequest },
+      { tableId: number; data: UpdateComparisonTableRequest },
       TContext
     >;
     request?: SecondParameter<typeof http>;
@@ -488,7 +704,7 @@ export const useUpdateComparisonTable = <TError = unknown, TContext = unknown>(
 ): UseMutationResult<
   Awaited<ReturnType<typeof updateComparisonTable>>,
   TError,
-  { tableId: number; data: CreateComparisonTableRequest },
+  { tableId: number; data: UpdateComparisonTableRequest },
   TContext
 > => {
   const mutationOptions = getUpdateComparisonTableMutationOptions(options);
@@ -497,7 +713,7 @@ export const useUpdateComparisonTable = <TError = unknown, TContext = unknown>(
 };
 
 /**
- * 비교표에 새로운 숙소를 추가합니다.
+ * 비교표에 새로운 숙소를 추가합니다. (Authorization 헤더에 Bearer 토큰 필요)
  * @summary 비교표 숙소 추가
  */
 export type addAccommodationToComparisonTableResponse200 = {
@@ -513,35 +729,22 @@ export type addAccommodationToComparisonTableResponse =
     headers: Headers;
   };
 
-export const getAddAccommodationToComparisonTableUrl = (
-  tableId: number,
-  params: AddAccommodationToComparisonTableParams,
-) => {
-  const normalizedParams = new URLSearchParams();
-
-  Object.entries(params || {}).forEach(([key, value]) => {
-    if (value !== undefined) {
-      normalizedParams.append(key, value === null ? "null" : value.toString());
-    }
-  });
-
-  const stringifiedParams = normalizedParams.toString();
-
-  return stringifiedParams.length > 0
-    ? `https://api.ssok.info/api/comparison/${tableId}?${stringifiedParams}`
-    : `https://api.ssok.info/api/comparison/${tableId}`;
+export const getAddAccommodationToComparisonTableUrl = (tableId: number) => {
+  return `https://api.ssok.info/api/comparison/${tableId}`;
 };
 
 export const addAccommodationToComparisonTable = async (
   tableId: number,
-  params: AddAccommodationToComparisonTableParams,
+  addAccommodationRequest: AddAccommodationRequest,
   options?: RequestInit,
 ): Promise<addAccommodationToComparisonTableResponse> => {
   return http<addAccommodationToComparisonTableResponse>(
-    getAddAccommodationToComparisonTableUrl(tableId, params),
+    getAddAccommodationToComparisonTableUrl(tableId),
     {
       ...options,
       method: "PATCH",
+      headers: { "Content-Type": "application/json", ...options?.headers },
+      body: JSON.stringify(addAccommodationRequest),
     },
   );
 };
@@ -553,14 +756,14 @@ export const getAddAccommodationToComparisonTableMutationOptions = <
   mutation?: UseMutationOptions<
     Awaited<ReturnType<typeof addAccommodationToComparisonTable>>,
     TError,
-    { tableId: number; params: AddAccommodationToComparisonTableParams },
+    { tableId: number; data: AddAccommodationRequest },
     TContext
   >;
   request?: SecondParameter<typeof http>;
 }): UseMutationOptions<
   Awaited<ReturnType<typeof addAccommodationToComparisonTable>>,
   TError,
-  { tableId: number; params: AddAccommodationToComparisonTableParams },
+  { tableId: number; data: AddAccommodationRequest },
   TContext
 > => {
   const mutationKey = ["addAccommodationToComparisonTable"];
@@ -574,11 +777,11 @@ export const getAddAccommodationToComparisonTableMutationOptions = <
 
   const mutationFn: MutationFunction<
     Awaited<ReturnType<typeof addAccommodationToComparisonTable>>,
-    { tableId: number; params: AddAccommodationToComparisonTableParams }
+    { tableId: number; data: AddAccommodationRequest }
   > = (props) => {
-    const { tableId, params } = props ?? {};
+    const { tableId, data } = props ?? {};
 
-    return addAccommodationToComparisonTable(tableId, params, requestOptions);
+    return addAccommodationToComparisonTable(tableId, data, requestOptions);
   };
 
   return { mutationFn, ...mutationOptions };
@@ -587,7 +790,8 @@ export const getAddAccommodationToComparisonTableMutationOptions = <
 export type AddAccommodationToComparisonTableMutationResult = NonNullable<
   Awaited<ReturnType<typeof addAccommodationToComparisonTable>>
 >;
-
+export type AddAccommodationToComparisonTableMutationBody =
+  AddAccommodationRequest;
 export type AddAccommodationToComparisonTableMutationError = unknown;
 
 /**
@@ -601,7 +805,7 @@ export const useAddAccommodationToComparisonTable = <
     mutation?: UseMutationOptions<
       Awaited<ReturnType<typeof addAccommodationToComparisonTable>>,
       TError,
-      { tableId: number; params: AddAccommodationToComparisonTableParams },
+      { tableId: number; data: AddAccommodationRequest },
       TContext
     >;
     request?: SecondParameter<typeof http>;
@@ -610,7 +814,7 @@ export const useAddAccommodationToComparisonTable = <
 ): UseMutationResult<
   Awaited<ReturnType<typeof addAccommodationToComparisonTable>>,
   TError,
-  { tableId: number; params: AddAccommodationToComparisonTableParams },
+  { tableId: number; data: AddAccommodationRequest },
   TContext
 > => {
   const mutationOptions =
@@ -620,7 +824,312 @@ export const useAddAccommodationToComparisonTable = <
 };
 
 /**
- * 비교표 이름, 숙소 ID 리스트, 비교 기준 항목을 받아서 비교표 메타 데이터를 생성합니다.
+ * 새로운 여행 보드를 생성합니다. JWT 인증을 통해 현재 사용자 정보를 추출하고, 생성자는 자동으로 OWNER 역할로 등록되며 고유한 초대 링크가 생성됩니다.
+ * @summary 여행 보드 생성
+ */
+export type createTripBoardResponse200 = {
+  data: StandardResponseTripBoardCreateResponse;
+  status: 200;
+};
+
+export type createTripBoardResponseComposite = createTripBoardResponse200;
+
+export type createTripBoardResponse = createTripBoardResponseComposite & {
+  headers: Headers;
+};
+
+export const getCreateTripBoardUrl = () => {
+  return `https://api.ssok.info/api/trip-boards/register`;
+};
+
+export const createTripBoard = async (
+  tripBoardCreateRequest: TripBoardCreateRequest,
+  options?: RequestInit,
+): Promise<createTripBoardResponse> => {
+  return http<createTripBoardResponse>(getCreateTripBoardUrl(), {
+    ...options,
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...options?.headers },
+    body: JSON.stringify(tripBoardCreateRequest),
+  });
+};
+
+export const getCreateTripBoardMutationOptions = <
+  TError = unknown,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof createTripBoard>>,
+    TError,
+    { data: TripBoardCreateRequest },
+    TContext
+  >;
+  request?: SecondParameter<typeof http>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof createTripBoard>>,
+  TError,
+  { data: TripBoardCreateRequest },
+  TContext
+> => {
+  const mutationKey = ["createTripBoard"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      "mutationKey" in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof createTripBoard>>,
+    { data: TripBoardCreateRequest }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return createTripBoard(data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type CreateTripBoardMutationResult = NonNullable<
+  Awaited<ReturnType<typeof createTripBoard>>
+>;
+export type CreateTripBoardMutationBody = TripBoardCreateRequest;
+export type CreateTripBoardMutationError = unknown;
+
+/**
+ * @summary 여행 보드 생성
+ */
+export const useCreateTripBoard = <TError = unknown, TContext = unknown>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof createTripBoard>>,
+      TError,
+      { data: TripBoardCreateRequest },
+      TContext
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof createTripBoard>>,
+  TError,
+  { data: TripBoardCreateRequest },
+  TContext
+> => {
+  const mutationOptions = getCreateTripBoardMutationOptions(options);
+
+  return useMutation(mutationOptions, queryClient);
+};
+
+/**
+ * 현재 로그인된 사용자의 세션을 종료합니다. 헤더에 있는 access-token 토큰을 블랙리스트에 추가합니다. Redis에서 Refresh Token을 삭제하고 브라우저의 REFRESH_TOKEN 쿠키를 무효화합니다. 로그아웃 후에는 새로운 인증이 필요합니다.
+ * @summary 사용자 로그아웃
+ */
+export type logoutResponse200 = {
+  data: StandardResponseLogoutResponse;
+  status: 200;
+};
+
+export type logoutResponseComposite = logoutResponse200;
+
+export type logoutResponse = logoutResponseComposite & {
+  headers: Headers;
+};
+
+export const getLogoutUrl = () => {
+  return `https://api.ssok.info/api/oauth/logout`;
+};
+
+export const logout = async (
+  options?: RequestInit,
+): Promise<logoutResponse> => {
+  return http<logoutResponse>(getLogoutUrl(), {
+    ...options,
+    method: "POST",
+  });
+};
+
+export const getLogoutMutationOptions = <
+  TError = unknown,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof logout>>,
+    TError,
+    void,
+    TContext
+  >;
+  request?: SecondParameter<typeof http>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof logout>>,
+  TError,
+  void,
+  TContext
+> => {
+  const mutationKey = ["logout"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      "mutationKey" in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof logout>>,
+    void
+  > = () => {
+    return logout(requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type LogoutMutationResult = NonNullable<
+  Awaited<ReturnType<typeof logout>>
+>;
+
+export type LogoutMutationError = unknown;
+
+/**
+ * @summary 사용자 로그아웃
+ */
+export const useLogout = <TError = unknown, TContext = unknown>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof logout>>,
+      TError,
+      void,
+      TContext
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof logout>>,
+  TError,
+  void,
+  TContext
+> => {
+  const mutationOptions = getLogoutMutationOptions(options);
+
+  return useMutation(mutationOptions, queryClient);
+};
+
+/**
+ * 카카오에서 발급받은 인가 코드를 통해 액세스 토큰을 획득하고, 사용자 정보를 조회하여 JWT 토큰을 헤더로 설정합니다. JWT 토큰은 응답 헤더로 전달되며, 응답 바디에는 사용자 정보만 포함됩니다. 인가 코드와 baseUrl은 Query Parameter로 전달해야 합니다. 로그인 성공 후 응답 헤더 access-token, 쿠키 REFRESH_TOKEN 로 각각 액세스 토큰, 리프레시 토큰이 전달됩니다.
+ * @summary 카카오 OAuth 토큰 교환
+ */
+export type exchangeKakaoTokenResponse200 = {
+  data: StandardResponseOauthLoginResponse;
+  status: 200;
+};
+
+export type exchangeKakaoTokenResponseComposite = exchangeKakaoTokenResponse200;
+
+export type exchangeKakaoTokenResponse = exchangeKakaoTokenResponseComposite & {
+  headers: Headers;
+};
+
+export const getExchangeKakaoTokenUrl = (params: ExchangeKakaoTokenParams) => {
+  const normalizedParams = new URLSearchParams();
+
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value !== undefined) {
+      normalizedParams.append(key, value === null ? "null" : value.toString());
+    }
+  });
+
+  const stringifiedParams = normalizedParams.toString();
+
+  return stringifiedParams.length > 0
+    ? `https://api.ssok.info/api/oauth/kakao/token?${stringifiedParams}`
+    : `https://api.ssok.info/api/oauth/kakao/token`;
+};
+
+export const exchangeKakaoToken = async (
+  params: ExchangeKakaoTokenParams,
+  options?: RequestInit,
+): Promise<exchangeKakaoTokenResponse> => {
+  return http<exchangeKakaoTokenResponse>(getExchangeKakaoTokenUrl(params), {
+    ...options,
+    method: "POST",
+  });
+};
+
+export const getExchangeKakaoTokenMutationOptions = <
+  TError = unknown,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof exchangeKakaoToken>>,
+    TError,
+    { params: ExchangeKakaoTokenParams },
+    TContext
+  >;
+  request?: SecondParameter<typeof http>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof exchangeKakaoToken>>,
+  TError,
+  { params: ExchangeKakaoTokenParams },
+  TContext
+> => {
+  const mutationKey = ["exchangeKakaoToken"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      "mutationKey" in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof exchangeKakaoToken>>,
+    { params: ExchangeKakaoTokenParams }
+  > = (props) => {
+    const { params } = props ?? {};
+
+    return exchangeKakaoToken(params, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type ExchangeKakaoTokenMutationResult = NonNullable<
+  Awaited<ReturnType<typeof exchangeKakaoToken>>
+>;
+
+export type ExchangeKakaoTokenMutationError = unknown;
+
+/**
+ * @summary 카카오 OAuth 토큰 교환
+ */
+export const useExchangeKakaoToken = <TError = unknown, TContext = unknown>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof exchangeKakaoToken>>,
+      TError,
+      { params: ExchangeKakaoTokenParams },
+      TContext
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof exchangeKakaoToken>>,
+  TError,
+  { params: ExchangeKakaoTokenParams },
+  TContext
+> => {
+  const mutationOptions = getExchangeKakaoTokenMutationOptions(options);
+
+  return useMutation(mutationOptions, queryClient);
+};
+
+/**
+ * 비교표 이름, 숙소 ID 리스트, 비교 기준 항목을 받아서 비교표 메타 데이터를 생성합니다. (Authorization 헤더에 Bearer 토큰 필요)
  * @summary 비교표 생성
  */
 export type createComparisonTableResponse200 = {
@@ -831,94 +1340,99 @@ export const useRegisterAccommodationCard = <
 };
 
 /**
- * 클라이언트 요청 시 카카오 OAuth2 인가 페이지로 리다이렉트하고, 인가 완료 시 쿠키에 ACCESS TOKEN 및 REFRESH TOKEN을 발급합니다.
- * @summary 카카오 소셜 로그인 리다이렉션
+ * 사용자가 참여한 여행 보드 목록을 페이징으로 조회합니다. JWT 인증을 통해 현재 사용자 정보를 추출하고, 최신순으로 정렬된 결과를 반환합니다.
+ * @summary 여행 보드 목록 조회
  */
-export type redirectToKakaoAuthorizationResponse302 = {
-  data: null;
-  status: 302;
+export type getTripBoardsResponse200 = {
+  data: StandardResponseTripBoardPageResponse;
+  status: 200;
 };
 
-export type redirectToKakaoAuthorizationResponseComposite =
-  redirectToKakaoAuthorizationResponse302;
+export type getTripBoardsResponseComposite = getTripBoardsResponse200;
 
-export type redirectToKakaoAuthorizationResponse =
-  redirectToKakaoAuthorizationResponseComposite & {
-    headers: Headers;
-  };
-
-export const getRedirectToKakaoAuthorizationUrl = () => {
-  return `https://api.ssok.info/api/oauth/kakao`;
+export type getTripBoardsResponse = getTripBoardsResponseComposite & {
+  headers: Headers;
 };
 
-export const redirectToKakaoAuthorization = async (
+export const getGetTripBoardsUrl = (params: GetTripBoardsParams) => {
+  const normalizedParams = new URLSearchParams();
+
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value !== undefined) {
+      normalizedParams.append(key, value === null ? "null" : value.toString());
+    }
+  });
+
+  const stringifiedParams = normalizedParams.toString();
+
+  return stringifiedParams.length > 0
+    ? `https://api.ssok.info/api/trip-boards/search?${stringifiedParams}`
+    : `https://api.ssok.info/api/trip-boards/search`;
+};
+
+export const getTripBoards = async (
+  params: GetTripBoardsParams,
   options?: RequestInit,
-): Promise<redirectToKakaoAuthorizationResponse> => {
-  return http<redirectToKakaoAuthorizationResponse>(
-    getRedirectToKakaoAuthorizationUrl(),
-    {
-      ...options,
-      method: "GET",
-    },
-  );
+): Promise<getTripBoardsResponse> => {
+  return http<getTripBoardsResponse>(getGetTripBoardsUrl(params), {
+    ...options,
+    method: "GET",
+  });
 };
 
-export const getRedirectToKakaoAuthorizationQueryKey = () => {
-  return [`https://api.ssok.info/api/oauth/kakao`] as const;
+export const getGetTripBoardsQueryKey = (params?: GetTripBoardsParams) => {
+  return [
+    `https://api.ssok.info/api/trip-boards/search`,
+    ...(params ? [params] : []),
+  ] as const;
 };
 
-export const getRedirectToKakaoAuthorizationQueryOptions = <
-  TData = Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
-  TError = null,
->(options?: {
-  query?: Partial<
-    UseQueryOptions<
-      Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
-      TError,
-      TData
-    >
-  >;
-  request?: SecondParameter<typeof http>;
-}) => {
+export const getGetTripBoardsQueryOptions = <
+  TData = Awaited<ReturnType<typeof getTripBoards>>,
+  TError = unknown,
+>(
+  params: GetTripBoardsParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getTripBoards>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+) => {
   const { query: queryOptions, request: requestOptions } = options ?? {};
 
-  const queryKey =
-    queryOptions?.queryKey ?? getRedirectToKakaoAuthorizationQueryKey();
+  const queryKey = queryOptions?.queryKey ?? getGetTripBoardsQueryKey(params);
 
-  const queryFn: QueryFunction<
-    Awaited<ReturnType<typeof redirectToKakaoAuthorization>>
-  > = ({ signal }) =>
-    redirectToKakaoAuthorization({ signal, ...requestOptions });
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getTripBoards>>> = ({
+    signal,
+  }) => getTripBoards(params, { signal, ...requestOptions });
 
   return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
-    Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
+    Awaited<ReturnType<typeof getTripBoards>>,
     TError,
     TData
   > & { queryKey: DataTag<QueryKey, TData> };
 };
 
-export type RedirectToKakaoAuthorizationQueryResult = NonNullable<
-  Awaited<ReturnType<typeof redirectToKakaoAuthorization>>
+export type GetTripBoardsQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getTripBoards>>
 >;
-export type RedirectToKakaoAuthorizationQueryError = null;
+export type GetTripBoardsQueryError = unknown;
 
-export function useRedirectToKakaoAuthorization<
-  TData = Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
-  TError = null,
+export function useGetTripBoards<
+  TData = Awaited<ReturnType<typeof getTripBoards>>,
+  TError = unknown,
 >(
+  params: GetTripBoardsParams,
   options: {
     query: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
-        TError,
-        TData
-      >
+      UseQueryOptions<Awaited<ReturnType<typeof getTripBoards>>, TError, TData>
     > &
       Pick<
         DefinedInitialDataOptions<
-          Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
+          Awaited<ReturnType<typeof getTripBoards>>,
           TError,
-          Awaited<ReturnType<typeof redirectToKakaoAuthorization>>
+          Awaited<ReturnType<typeof getTripBoards>>
         >,
         "initialData"
       >;
@@ -928,23 +1442,20 @@ export function useRedirectToKakaoAuthorization<
 ): DefinedUseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
 };
-export function useRedirectToKakaoAuthorization<
-  TData = Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
-  TError = null,
+export function useGetTripBoards<
+  TData = Awaited<ReturnType<typeof getTripBoards>>,
+  TError = unknown,
 >(
+  params: GetTripBoardsParams,
   options?: {
     query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
-        TError,
-        TData
-      >
+      UseQueryOptions<Awaited<ReturnType<typeof getTripBoards>>, TError, TData>
     > &
       Pick<
         UndefinedInitialDataOptions<
-          Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
+          Awaited<ReturnType<typeof getTripBoards>>,
           TError,
-          Awaited<ReturnType<typeof redirectToKakaoAuthorization>>
+          Awaited<ReturnType<typeof getTripBoards>>
         >,
         "initialData"
       >;
@@ -952,43 +1463,37 @@ export function useRedirectToKakaoAuthorization<
   },
   queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> };
-export function useRedirectToKakaoAuthorization<
-  TData = Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
-  TError = null,
+export function useGetTripBoards<
+  TData = Awaited<ReturnType<typeof getTripBoards>>,
+  TError = unknown,
 >(
+  params: GetTripBoardsParams,
   options?: {
     query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
-        TError,
-        TData
-      >
+      UseQueryOptions<Awaited<ReturnType<typeof getTripBoards>>, TError, TData>
     >;
     request?: SecondParameter<typeof http>;
   },
   queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> };
 /**
- * @summary 카카오 소셜 로그인 리다이렉션
+ * @summary 여행 보드 목록 조회
  */
 
-export function useRedirectToKakaoAuthorization<
-  TData = Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
-  TError = null,
+export function useGetTripBoards<
+  TData = Awaited<ReturnType<typeof getTripBoards>>,
+  TError = unknown,
 >(
+  params: GetTripBoardsParams,
   options?: {
     query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
-        TError,
-        TData
-      >
+      UseQueryOptions<Awaited<ReturnType<typeof getTripBoards>>, TError, TData>
     >;
     request?: SecondParameter<typeof http>;
   },
   queryClient?: QueryClient,
 ): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> } {
-  const queryOptions = getRedirectToKakaoAuthorizationQueryOptions(options);
+  const queryOptions = getGetTripBoardsQueryOptions(params, options);
 
   const query = useQuery(queryOptions, queryClient) as UseQueryResult<
     TData,
@@ -1001,74 +1506,73 @@ export function useRedirectToKakaoAuthorization<
 }
 
 /**
- * @summary 카카오 소셜 로그인 리다이렉션
+ * @summary 여행 보드 목록 조회
  */
-export const prefetchRedirectToKakaoAuthorizationQuery = async <
-  TData = Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
-  TError = null,
+export const prefetchGetTripBoardsQuery = async <
+  TData = Awaited<ReturnType<typeof getTripBoards>>,
+  TError = unknown,
 >(
   queryClient: QueryClient,
+  params: GetTripBoardsParams,
   options?: {
     query?: Partial<
-      UseQueryOptions<
-        Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
-        TError,
-        TData
-      >
+      UseQueryOptions<Awaited<ReturnType<typeof getTripBoards>>, TError, TData>
     >;
     request?: SecondParameter<typeof http>;
   },
 ): Promise<QueryClient> => {
-  const queryOptions = getRedirectToKakaoAuthorizationQueryOptions(options);
+  const queryOptions = getGetTripBoardsQueryOptions(params, options);
 
   await queryClient.prefetchQuery(queryOptions);
 
   return queryClient;
 };
 
-export const getRedirectToKakaoAuthorizationSuspenseQueryOptions = <
-  TData = Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
-  TError = null,
->(options?: {
-  query?: Partial<
-    UseSuspenseQueryOptions<
-      Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
-      TError,
-      TData
-    >
-  >;
-  request?: SecondParameter<typeof http>;
-}) => {
+export const getGetTripBoardsSuspenseQueryOptions = <
+  TData = Awaited<ReturnType<typeof getTripBoards>>,
+  TError = unknown,
+>(
+  params: GetTripBoardsParams,
+  options?: {
+    query?: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getTripBoards>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+) => {
   const { query: queryOptions, request: requestOptions } = options ?? {};
 
-  const queryKey =
-    queryOptions?.queryKey ?? getRedirectToKakaoAuthorizationQueryKey();
+  const queryKey = queryOptions?.queryKey ?? getGetTripBoardsQueryKey(params);
 
-  const queryFn: QueryFunction<
-    Awaited<ReturnType<typeof redirectToKakaoAuthorization>>
-  > = ({ signal }) =>
-    redirectToKakaoAuthorization({ signal, ...requestOptions });
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getTripBoards>>> = ({
+    signal,
+  }) => getTripBoards(params, { signal, ...requestOptions });
 
   return { queryKey, queryFn, ...queryOptions } as UseSuspenseQueryOptions<
-    Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
+    Awaited<ReturnType<typeof getTripBoards>>,
     TError,
     TData
   > & { queryKey: DataTag<QueryKey, TData> };
 };
 
-export type RedirectToKakaoAuthorizationSuspenseQueryResult = NonNullable<
-  Awaited<ReturnType<typeof redirectToKakaoAuthorization>>
+export type GetTripBoardsSuspenseQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getTripBoards>>
 >;
-export type RedirectToKakaoAuthorizationSuspenseQueryError = null;
+export type GetTripBoardsSuspenseQueryError = unknown;
 
-export function useRedirectToKakaoAuthorizationSuspense<
-  TData = Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
-  TError = null,
+export function useGetTripBoardsSuspense<
+  TData = Awaited<ReturnType<typeof getTripBoards>>,
+  TError = unknown,
 >(
+  params: GetTripBoardsParams,
   options: {
     query: Partial<
       UseSuspenseQueryOptions<
-        Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
+        Awaited<ReturnType<typeof getTripBoards>>,
         TError,
         TData
       >
@@ -1079,14 +1583,15 @@ export function useRedirectToKakaoAuthorizationSuspense<
 ): UseSuspenseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
 };
-export function useRedirectToKakaoAuthorizationSuspense<
-  TData = Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
-  TError = null,
+export function useGetTripBoardsSuspense<
+  TData = Awaited<ReturnType<typeof getTripBoards>>,
+  TError = unknown,
 >(
+  params: GetTripBoardsParams,
   options?: {
     query?: Partial<
       UseSuspenseQueryOptions<
-        Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
+        Awaited<ReturnType<typeof getTripBoards>>,
         TError,
         TData
       >
@@ -1097,14 +1602,15 @@ export function useRedirectToKakaoAuthorizationSuspense<
 ): UseSuspenseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
 };
-export function useRedirectToKakaoAuthorizationSuspense<
-  TData = Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
-  TError = null,
+export function useGetTripBoardsSuspense<
+  TData = Awaited<ReturnType<typeof getTripBoards>>,
+  TError = unknown,
 >(
+  params: GetTripBoardsParams,
   options?: {
     query?: Partial<
       UseSuspenseQueryOptions<
-        Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
+        Awaited<ReturnType<typeof getTripBoards>>,
         TError,
         TData
       >
@@ -1116,17 +1622,18 @@ export function useRedirectToKakaoAuthorizationSuspense<
   queryKey: DataTag<QueryKey, TData>;
 };
 /**
- * @summary 카카오 소셜 로그인 리다이렉션
+ * @summary 여행 보드 목록 조회
  */
 
-export function useRedirectToKakaoAuthorizationSuspense<
-  TData = Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
-  TError = null,
+export function useGetTripBoardsSuspense<
+  TData = Awaited<ReturnType<typeof getTripBoards>>,
+  TError = unknown,
 >(
+  params: GetTripBoardsParams,
   options?: {
     query?: Partial<
       UseSuspenseQueryOptions<
-        Awaited<ReturnType<typeof redirectToKakaoAuthorization>>,
+        Awaited<ReturnType<typeof getTripBoards>>,
         TError,
         TData
       >
@@ -1137,8 +1644,366 @@ export function useRedirectToKakaoAuthorizationSuspense<
 ): UseSuspenseQueryResult<TData, TError> & {
   queryKey: DataTag<QueryKey, TData>;
 } {
-  const queryOptions =
-    getRedirectToKakaoAuthorizationSuspenseQueryOptions(options);
+  const queryOptions = getGetTripBoardsSuspenseQueryOptions(params, options);
+
+  const query = useSuspenseQuery(
+    queryOptions,
+    queryClient,
+  ) as UseSuspenseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData>;
+  };
+
+  query.queryKey = queryOptions.queryKey;
+
+  return query;
+}
+
+/**
+ * 카카오 OAuth 인가 페이지 URL을 반환합니다. 클라이언트의 baseUrl을 기반으로 동적으로 redirect_uri를 생성합니다. 프론트엔드에서 이 URL로 리다이렉트하여 사용자 인증을 진행합니다.
+ * @summary 카카오 OAuth 인가 URL 조회
+ */
+export type getKakaoAuthorizeUrlResponse200 = {
+  data: StandardResponseAuthorizeUrlResponse;
+  status: 200;
+};
+
+export type getKakaoAuthorizeUrlResponseComposite =
+  getKakaoAuthorizeUrlResponse200;
+
+export type getKakaoAuthorizeUrlResponse =
+  getKakaoAuthorizeUrlResponseComposite & {
+    headers: Headers;
+  };
+
+export const getGetKakaoAuthorizeUrlUrl = (
+  params: GetKakaoAuthorizeUrlParams,
+) => {
+  const normalizedParams = new URLSearchParams();
+
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value !== undefined) {
+      normalizedParams.append(key, value === null ? "null" : value.toString());
+    }
+  });
+
+  const stringifiedParams = normalizedParams.toString();
+
+  return stringifiedParams.length > 0
+    ? `https://api.ssok.info/api/oauth/kakao/authorize?${stringifiedParams}`
+    : `https://api.ssok.info/api/oauth/kakao/authorize`;
+};
+
+export const getKakaoAuthorizeUrl = async (
+  params: GetKakaoAuthorizeUrlParams,
+  options?: RequestInit,
+): Promise<getKakaoAuthorizeUrlResponse> => {
+  return http<getKakaoAuthorizeUrlResponse>(
+    getGetKakaoAuthorizeUrlUrl(params),
+    {
+      ...options,
+      method: "GET",
+    },
+  );
+};
+
+export const getGetKakaoAuthorizeUrlQueryKey = (
+  params?: GetKakaoAuthorizeUrlParams,
+) => {
+  return [
+    `https://api.ssok.info/api/oauth/kakao/authorize`,
+    ...(params ? [params] : []),
+  ] as const;
+};
+
+export const getGetKakaoAuthorizeUrlQueryOptions = <
+  TData = Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+  TError = unknown,
+>(
+  params: GetKakaoAuthorizeUrlParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ?? getGetKakaoAuthorizeUrlQueryKey(params);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>
+  > = ({ signal }) =>
+    getKakaoAuthorizeUrl(params, { signal, ...requestOptions });
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData> };
+};
+
+export type GetKakaoAuthorizeUrlQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>
+>;
+export type GetKakaoAuthorizeUrlQueryError = unknown;
+
+export function useGetKakaoAuthorizeUrl<
+  TData = Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+  TError = unknown,
+>(
+  params: GetKakaoAuthorizeUrlParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+          TError,
+          Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData>;
+};
+export function useGetKakaoAuthorizeUrl<
+  TData = Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+  TError = unknown,
+>(
+  params: GetKakaoAuthorizeUrlParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+          TError,
+          Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> };
+export function useGetKakaoAuthorizeUrl<
+  TData = Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+  TError = unknown,
+>(
+  params: GetKakaoAuthorizeUrlParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> };
+/**
+ * @summary 카카오 OAuth 인가 URL 조회
+ */
+
+export function useGetKakaoAuthorizeUrl<
+  TData = Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+  TError = unknown,
+>(
+  params: GetKakaoAuthorizeUrlParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> } {
+  const queryOptions = getGetKakaoAuthorizeUrlQueryOptions(params, options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData> };
+
+  query.queryKey = queryOptions.queryKey;
+
+  return query;
+}
+
+/**
+ * @summary 카카오 OAuth 인가 URL 조회
+ */
+export const prefetchGetKakaoAuthorizeUrlQuery = async <
+  TData = Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+  TError = unknown,
+>(
+  queryClient: QueryClient,
+  params: GetKakaoAuthorizeUrlParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+): Promise<QueryClient> => {
+  const queryOptions = getGetKakaoAuthorizeUrlQueryOptions(params, options);
+
+  await queryClient.prefetchQuery(queryOptions);
+
+  return queryClient;
+};
+
+export const getGetKakaoAuthorizeUrlSuspenseQueryOptions = <
+  TData = Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+  TError = unknown,
+>(
+  params: GetKakaoAuthorizeUrlParams,
+  options?: {
+    query?: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ?? getGetKakaoAuthorizeUrlQueryKey(params);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>
+  > = ({ signal }) =>
+    getKakaoAuthorizeUrl(params, { signal, ...requestOptions });
+
+  return { queryKey, queryFn, ...queryOptions } as UseSuspenseQueryOptions<
+    Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData> };
+};
+
+export type GetKakaoAuthorizeUrlSuspenseQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>
+>;
+export type GetKakaoAuthorizeUrlSuspenseQueryError = unknown;
+
+export function useGetKakaoAuthorizeUrlSuspense<
+  TData = Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+  TError = unknown,
+>(
+  params: GetKakaoAuthorizeUrlParams,
+  options: {
+    query: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseSuspenseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData>;
+};
+export function useGetKakaoAuthorizeUrlSuspense<
+  TData = Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+  TError = unknown,
+>(
+  params: GetKakaoAuthorizeUrlParams,
+  options?: {
+    query?: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseSuspenseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData>;
+};
+export function useGetKakaoAuthorizeUrlSuspense<
+  TData = Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+  TError = unknown,
+>(
+  params: GetKakaoAuthorizeUrlParams,
+  options?: {
+    query?: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseSuspenseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData>;
+};
+/**
+ * @summary 카카오 OAuth 인가 URL 조회
+ */
+
+export function useGetKakaoAuthorizeUrlSuspense<
+  TData = Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+  TError = unknown,
+>(
+  params: GetKakaoAuthorizeUrlParams,
+  options?: {
+    query?: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getKakaoAuthorizeUrl>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseSuspenseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData>;
+} {
+  const queryOptions = getGetKakaoAuthorizeUrlSuspenseQueryOptions(
+    params,
+    options,
+  );
 
   const query = useSuspenseQuery(
     queryOptions,
@@ -1458,6 +2323,320 @@ export function useGetComparisonFactorListSuspense<
   queryKey: DataTag<QueryKey, TData>;
 } {
   const queryOptions = getGetComparisonFactorListSuspenseQueryOptions(options);
+
+  const query = useSuspenseQuery(
+    queryOptions,
+    queryClient,
+  ) as UseSuspenseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData>;
+  };
+
+  query.queryKey = queryOptions.queryKey;
+
+  return query;
+}
+
+/**
+ * 편의 서비스 항목 Enum 리스트를 반환합니다.
+ * @summary 편의 서비스 Enum 리스트
+ */
+export type getAmenityFactorListResponse200 = {
+  data: StandardResponseAmenityFactorList;
+  status: 200;
+};
+
+export type getAmenityFactorListResponseComposite =
+  getAmenityFactorListResponse200;
+
+export type getAmenityFactorListResponse =
+  getAmenityFactorListResponseComposite & {
+    headers: Headers;
+  };
+
+export const getGetAmenityFactorListUrl = () => {
+  return `https://api.ssok.info/api/comparison/amenity`;
+};
+
+export const getAmenityFactorList = async (
+  options?: RequestInit,
+): Promise<getAmenityFactorListResponse> => {
+  return http<getAmenityFactorListResponse>(getGetAmenityFactorListUrl(), {
+    ...options,
+    method: "GET",
+  });
+};
+
+export const getGetAmenityFactorListQueryKey = () => {
+  return [`https://api.ssok.info/api/comparison/amenity`] as const;
+};
+
+export const getGetAmenityFactorListQueryOptions = <
+  TData = Awaited<ReturnType<typeof getAmenityFactorList>>,
+  TError = unknown,
+>(options?: {
+  query?: Partial<
+    UseQueryOptions<
+      Awaited<ReturnType<typeof getAmenityFactorList>>,
+      TError,
+      TData
+    >
+  >;
+  request?: SecondParameter<typeof http>;
+}) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getGetAmenityFactorListQueryKey();
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof getAmenityFactorList>>
+  > = ({ signal }) => getAmenityFactorList({ signal, ...requestOptions });
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof getAmenityFactorList>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData> };
+};
+
+export type GetAmenityFactorListQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getAmenityFactorList>>
+>;
+export type GetAmenityFactorListQueryError = unknown;
+
+export function useGetAmenityFactorList<
+  TData = Awaited<ReturnType<typeof getAmenityFactorList>>,
+  TError = unknown,
+>(
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getAmenityFactorList>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getAmenityFactorList>>,
+          TError,
+          Awaited<ReturnType<typeof getAmenityFactorList>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData>;
+};
+export function useGetAmenityFactorList<
+  TData = Awaited<ReturnType<typeof getAmenityFactorList>>,
+  TError = unknown,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getAmenityFactorList>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getAmenityFactorList>>,
+          TError,
+          Awaited<ReturnType<typeof getAmenityFactorList>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> };
+export function useGetAmenityFactorList<
+  TData = Awaited<ReturnType<typeof getAmenityFactorList>>,
+  TError = unknown,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getAmenityFactorList>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> };
+/**
+ * @summary 편의 서비스 Enum 리스트
+ */
+
+export function useGetAmenityFactorList<
+  TData = Awaited<ReturnType<typeof getAmenityFactorList>>,
+  TError = unknown,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getAmenityFactorList>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> } {
+  const queryOptions = getGetAmenityFactorListQueryOptions(options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData> };
+
+  query.queryKey = queryOptions.queryKey;
+
+  return query;
+}
+
+/**
+ * @summary 편의 서비스 Enum 리스트
+ */
+export const prefetchGetAmenityFactorListQuery = async <
+  TData = Awaited<ReturnType<typeof getAmenityFactorList>>,
+  TError = unknown,
+>(
+  queryClient: QueryClient,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getAmenityFactorList>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+): Promise<QueryClient> => {
+  const queryOptions = getGetAmenityFactorListQueryOptions(options);
+
+  await queryClient.prefetchQuery(queryOptions);
+
+  return queryClient;
+};
+
+export const getGetAmenityFactorListSuspenseQueryOptions = <
+  TData = Awaited<ReturnType<typeof getAmenityFactorList>>,
+  TError = unknown,
+>(options?: {
+  query?: Partial<
+    UseSuspenseQueryOptions<
+      Awaited<ReturnType<typeof getAmenityFactorList>>,
+      TError,
+      TData
+    >
+  >;
+  request?: SecondParameter<typeof http>;
+}) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getGetAmenityFactorListQueryKey();
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof getAmenityFactorList>>
+  > = ({ signal }) => getAmenityFactorList({ signal, ...requestOptions });
+
+  return { queryKey, queryFn, ...queryOptions } as UseSuspenseQueryOptions<
+    Awaited<ReturnType<typeof getAmenityFactorList>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData> };
+};
+
+export type GetAmenityFactorListSuspenseQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getAmenityFactorList>>
+>;
+export type GetAmenityFactorListSuspenseQueryError = unknown;
+
+export function useGetAmenityFactorListSuspense<
+  TData = Awaited<ReturnType<typeof getAmenityFactorList>>,
+  TError = unknown,
+>(
+  options: {
+    query: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getAmenityFactorList>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseSuspenseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData>;
+};
+export function useGetAmenityFactorListSuspense<
+  TData = Awaited<ReturnType<typeof getAmenityFactorList>>,
+  TError = unknown,
+>(
+  options?: {
+    query?: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getAmenityFactorList>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseSuspenseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData>;
+};
+export function useGetAmenityFactorListSuspense<
+  TData = Awaited<ReturnType<typeof getAmenityFactorList>>,
+  TError = unknown,
+>(
+  options?: {
+    query?: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getAmenityFactorList>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseSuspenseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData>;
+};
+/**
+ * @summary 편의 서비스 Enum 리스트
+ */
+
+export function useGetAmenityFactorListSuspense<
+  TData = Awaited<ReturnType<typeof getAmenityFactorList>>,
+  TError = unknown,
+>(
+  options?: {
+    query?: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getAmenityFactorList>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseSuspenseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData>;
+} {
+  const queryOptions = getGetAmenityFactorListSuspenseQueryOptions(options);
 
   const query = useSuspenseQuery(
     queryOptions,
@@ -2741,3 +3920,104 @@ export function useGetAccommodationCountByBoardIdSuspense<
 
   return query;
 }
+
+/**
+ * 여행 보드에서 나갑니다. OWNER인 경우 가장 먼저 입장한 MEMBER에게 권한이 이양되며, 마지막 참여자인 경우 여행보드가 삭제됩니다. 나가는 사용자는 자신이 생성한 리소스(비교표, 숙소)를 유지하거나 제거할 수 있습니다.
+ * @summary 여행 보드 나가기
+ */
+export type leaveTripBoardResponse200 = {
+  data: StandardResponseTripBoardLeaveResponse;
+  status: 200;
+};
+
+export type leaveTripBoardResponseComposite = leaveTripBoardResponse200;
+
+export type leaveTripBoardResponse = leaveTripBoardResponseComposite & {
+  headers: Headers;
+};
+
+export const getLeaveTripBoardUrl = (boardId: number) => {
+  return `https://api.ssok.info/api/trip-boards/leave/${boardId}`;
+};
+
+export const leaveTripBoard = async (
+  boardId: number,
+  tripBoardLeaveRequest: TripBoardLeaveRequest,
+  options?: RequestInit,
+): Promise<leaveTripBoardResponse> => {
+  return http<leaveTripBoardResponse>(getLeaveTripBoardUrl(boardId), {
+    ...options,
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...options?.headers },
+    body: JSON.stringify(tripBoardLeaveRequest),
+  });
+};
+
+export const getLeaveTripBoardMutationOptions = <
+  TError = unknown,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof leaveTripBoard>>,
+    TError,
+    { boardId: number; data: TripBoardLeaveRequest },
+    TContext
+  >;
+  request?: SecondParameter<typeof http>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof leaveTripBoard>>,
+  TError,
+  { boardId: number; data: TripBoardLeaveRequest },
+  TContext
+> => {
+  const mutationKey = ["leaveTripBoard"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      "mutationKey" in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof leaveTripBoard>>,
+    { boardId: number; data: TripBoardLeaveRequest }
+  > = (props) => {
+    const { boardId, data } = props ?? {};
+
+    return leaveTripBoard(boardId, data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type LeaveTripBoardMutationResult = NonNullable<
+  Awaited<ReturnType<typeof leaveTripBoard>>
+>;
+export type LeaveTripBoardMutationBody = TripBoardLeaveRequest;
+export type LeaveTripBoardMutationError = unknown;
+
+/**
+ * @summary 여행 보드 나가기
+ */
+export const useLeaveTripBoard = <TError = unknown, TContext = unknown>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof leaveTripBoard>>,
+      TError,
+      { boardId: number; data: TripBoardLeaveRequest },
+      TContext
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof leaveTripBoard>>,
+  TError,
+  { boardId: number; data: TripBoardLeaveRequest },
+  TContext
+> => {
+  const mutationOptions = getLeaveTripBoardMutationOptions(options);
+
+  return useMutation(mutationOptions, queryClient);
+};


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 서버 측에서 `boardId`와 `tripBoardId`를 혼용하여 사용하는 부분을 우선 `boardId`로 통일했습니다. (path parameter에서 사용하여 transform으로 사용해도 문제 없음)
- `checkInTime`, `useRegisterAccommodationCard` 등 스키마가 변경된 부분에서 발생하는 타입 오류, 빌드 오류를 대응했습니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
commit-id:a1981826

---

**Stack**:
- #112
- #111
- #110 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **신규 기능**
  * 여행 보드(Trip Board) 생성, 수정, 삭제, 나가기 등 관리 기능이 추가되었습니다.
  * 여행 보드 목록 조회, 비교 요소 및 편의시설 요소 목록 API가 제공됩니다.
  * 카카오 OAuth 연동: 토큰 교환, 로그아웃, 인증 URL 조회 기능이 추가되었습니다.

* **기능 개선**
  * 비교표, 숙소 관련 API 및 데이터 구조가 통일되고, 체크인/체크아웃 시간 필드명이 간소화되었습니다.
  * API 인증이 강화되어 JWT 인증이 필요합니다.

* **버그 수정**
  * 일부 내부 데이터 필드명 및 응답 구조가 일관성 있게 정리되었습니다.

* **테스트**
  * 여행 보드, OAuth, 비교표 등 주요 API의 목(mock) 응답 및 테스트 핸들러가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->