### PR TITLE
[Y26W2-256] feat(ui): Date Picker 구현 

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -30,6 +30,7 @@
     "globby": "^14.1.0",
     "pretendard": "^1.3.9",
     "react": "^19.1.0",
+    "react-day-picker": "^9.8.1",
     "react-dom": "^19.1.0",
     "react-textarea-autosize": "^8.5.9",
     "tailwind-merge": "^3.3.0",

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -24,7 +24,7 @@
   }
 }
 
-@layer components {
+@layer utilities {
   .rdp-range_start {
     @apply !bg-[#edf9f5];
   }

--- a/packages/ui/src/app.css
+++ b/packages/ui/src/app.css
@@ -23,3 +23,20 @@
     font: inherit;
   }
 }
+
+@layer components {
+  .rdp-range_start {
+    @apply !bg-[#edf9f5];
+  }
+
+  .rdp-range_end {
+    @apply !bg-[#edf9f5];
+  }
+
+  .rdp-range_start .rdp-day_button {
+    @apply !bg-primary text-primary-100;
+  }
+  .rdp-range_end .rdp-day_button {
+    @apply !bg-primary text-primary-100;
+  }
+}

--- a/packages/ui/src/components/calendar/calendar.stories.tsx
+++ b/packages/ui/src/components/calendar/calendar.stories.tsx
@@ -1,6 +1,7 @@
 import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import type { DateRange } from "react-day-picker";
 import Calendar from ".";
-import "react-day-picker/dist/style.css"; // react-day-picker 기본 스타일
 
 const meta: Meta<typeof Calendar> = {
   title: "Components/Calendar",
@@ -14,5 +15,33 @@ export default meta;
 type Story = StoryObj<typeof Calendar>;
 
 export const Default: Story = {
-  render: () => <Calendar />,
+  render: () => {
+    const _Wrapper = () => {
+      const [selectedDate, setSelectedDate] = useState<DateRange | undefined>(
+        undefined,
+      );
+
+      const onDateSelect = (date: DateRange | undefined) => {
+        setSelectedDate(date);
+      };
+
+      const _onApplyDate = () => {
+        if (!selectedDate) {
+          alert("날짜를 선택해주세요.");
+          return;
+        }
+        alert(`선택된 날짜는: ${JSON.stringify(selectedDate)}`);
+      };
+
+      return (
+        <Calendar
+          selectedDate={selectedDate}
+          onDateSelect={onDateSelect}
+          onApplyDate={_onApplyDate}
+        />
+      );
+    };
+
+    return <_Wrapper />;
+  },
 };

--- a/packages/ui/src/components/calendar/calendar.stories.tsx
+++ b/packages/ui/src/components/calendar/calendar.stories.tsx
@@ -1,0 +1,18 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import Calendar from ".";
+import "react-day-picker/dist/style.css"; // react-day-picker 기본 스타일
+
+const meta: Meta<typeof Calendar> = {
+  title: "Components/Calendar",
+  component: Calendar,
+  parameters: {
+    layout: "centered",
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Calendar>;
+
+export const Default: Story = {
+  render: () => <Calendar />,
+};

--- a/packages/ui/src/components/calendar/index.tsx
+++ b/packages/ui/src/components/calendar/index.tsx
@@ -1,33 +1,35 @@
 import { IcArrowLeft, IcArrowRight } from "dist";
-import { useState } from "react";
-import "../../app.css";
 import {
   type DateRange,
   DayPicker,
   getDefaultClassNames,
 } from "react-day-picker";
+import "react-day-picker/dist/style.css";
 import { ko } from "react-day-picker/locale";
-import { cn } from "@/utils";
 
-const Calendar = () => {
+type CalendarProps = {
+  selectedDate: DateRange | undefined;
+  onDateSelect: (date: DateRange | undefined) => void;
+  onApplyDate: () => void;
+};
+
+const Calendar = ({
+  selectedDate,
+  onDateSelect,
+  onApplyDate,
+}: CalendarProps) => {
   const defaultClassNames = getDefaultClassNames();
-  const [selected, setSelectedd] = useState<DateRange | undefined>();
-
-  // const formatCaption = (date: Date) => {
-  //   return date
-  //     .toLocaleDateString("ko-KR", { year: "numeric", month: "numeric" })
-  //     .replace(".", "년")
-  //     .replace(".", "월")
-  //     .trim();
-  // };
-
+  // TODO: 년도 / 월 선택 컴포넌트 커스터마이징
   return (
-    <section className="rounded-[0.8rem] border border-neutral-90 bg-neutral-100 px-[1.2rem] py-[2rem] shadow-[4px_4px_8px_0_rgba(0,0,0,0.15)]">
+    <section className="rounded-[0.8rem] border border-neutral-90 bg-neutral-100 px-[1.2rem] pt-[2rem] shadow-[4px_4px_8px_0_rgba(0,0,0,0.15)]">
       <DayPicker
         locale={ko}
+        startMonth={new Date(new Date().getFullYear(), 0)}
+        endMonth={new Date(new Date().getFullYear() + 10, 11)}
         captionLayout="dropdown"
-        // formatters={{ formatCaption }}
-        components={{ Chevron: Chevron }}
+        components={{
+          Chevron: Chevron,
+        }}
         classNames={{
           root: `${defaultClassNames.root}`,
           nav: `${defaultClassNames.nav} gap-[0.8rem]`,
@@ -38,14 +40,24 @@ const Calendar = () => {
           today: `text-neutral-20`,
           day: `w-[3.6rem] h-[3.6rem] text-center text-caption1-medi12 text-neutral-20`,
           selected: `text-body1-medi16 text-neutral-20 border-0 bg-[#edf9f5]`,
-          range_start: cn(`${defaultClassNames.range_start}`),
           range_middle: `bg-[#edf9f5] text-neutral-20`,
-          range_end: cn(`${defaultClassNames.range_end}`),
+          range_start: `${defaultClassNames.range_start} !bg-none rounded-l-[50%]`,
+          range_end: `${defaultClassNames.range_end} !bg-none rounded-r-[50%]`,
         }}
         mode="range"
-        selected={selected}
-        onSelect={setSelectedd}
+        selected={selectedDate}
+        onSelect={onDateSelect}
+        disabled={{ before: new Date() }}
       />
+      <div className="px-[1.2rem] py-[1rem]">
+        <button
+          type="button"
+          className="flex w-full justify-end px-[0.4rem] py-[0.7rem] text-body2-semi14 text-primary"
+          onClick={onApplyDate}
+        >
+          적용
+        </button>
+      </div>
     </section>
   );
 };
@@ -73,49 +85,5 @@ const Chevron = ({
     </div>
   );
 };
-
-// function _CustomCaption({
-//   displayMonth,
-//   onMonthChange,
-//   className,
-// }: CaptionProps) {
-//   const year = displayMonth.getFullYear();
-//   const month = displayMonth.getMonth(); // 0-based
-
-//   const prevMonth = () => {
-//     const prev = new Date(year, month - 1);
-//     onMonthChange(prev);
-//   };
-//   const nextMonth = () => {
-//     const next = new Date(year, month + 1);
-//     onMonthChange(next);
-//   };
-
-//   return (
-//     <div className={`${className} flex items-center justify-between px-4 py-2`}>
-//       <button
-//         type="button"
-//         onClick={prevMonth}
-//         className="flex items-center justify-center p-1"
-//         aria-label="Previous month"
-//       >
-//         <IcArrowLeft className="h-5 w-5 text-neutral-60" />
-//       </button>
-
-//       <div className="text-body1-medi16 text-neutral-20">
-//         {year}년 {month + 1}월
-//       </div>
-
-//       <button
-//         type="button"
-//         onClick={nextMonth}
-//         className="flex items-center justify-center p-1"
-//         aria-label="Next month"
-//       >
-//         <IcArrowRight className="h-5 w-5 text-neutral-60" />
-//       </button>
-//     </div>
-//   );
-// }
 
 export default Calendar;

--- a/packages/ui/src/components/calendar/index.tsx
+++ b/packages/ui/src/components/calendar/index.tsx
@@ -1,0 +1,121 @@
+import { IcArrowLeft, IcArrowRight } from "dist";
+import { useState } from "react";
+import "../../app.css";
+import {
+  type DateRange,
+  DayPicker,
+  getDefaultClassNames,
+} from "react-day-picker";
+import { ko } from "react-day-picker/locale";
+import { cn } from "@/utils";
+
+const Calendar = () => {
+  const defaultClassNames = getDefaultClassNames();
+  const [selected, setSelectedd] = useState<DateRange | undefined>();
+
+  // const formatCaption = (date: Date) => {
+  //   return date
+  //     .toLocaleDateString("ko-KR", { year: "numeric", month: "numeric" })
+  //     .replace(".", "년")
+  //     .replace(".", "월")
+  //     .trim();
+  // };
+
+  return (
+    <section className="rounded-[0.8rem] border border-neutral-90 bg-neutral-100 px-[1.2rem] py-[2rem] shadow-[4px_4px_8px_0_rgba(0,0,0,0.15)]">
+      <DayPicker
+        locale={ko}
+        captionLayout="dropdown"
+        // formatters={{ formatCaption }}
+        components={{ Chevron: Chevron }}
+        classNames={{
+          root: `${defaultClassNames.root}`,
+          nav: `${defaultClassNames.nav} gap-[0.8rem]`,
+          month: `flex flex-col gap-[1rem]`,
+          month_caption: `px-[1.2rem]`,
+          caption_label: `text-body1-medi16 text-neutral-20`,
+          weekday: `w-[3.6rem] h-[3.6rem] text-center text-caption1-medi12 text-neutral-60`,
+          today: `text-neutral-20`,
+          day: `w-[3.6rem] h-[3.6rem] text-center text-caption1-medi12 text-neutral-20`,
+          selected: `text-body1-medi16 text-neutral-20 border-0 bg-[#edf9f5]`,
+          range_start: cn(`${defaultClassNames.range_start}`),
+          range_middle: `bg-[#edf9f5] text-neutral-20`,
+          range_end: cn(`${defaultClassNames.range_end}`),
+        }}
+        mode="range"
+        selected={selected}
+        onSelect={setSelectedd}
+      />
+    </section>
+  );
+};
+
+type ChevronProps = {
+  className?: string;
+  size?: number;
+  disabled?: boolean;
+  orientation?: "left" | "right" | "up" | "down";
+};
+
+const Chevron = ({
+  className,
+  size = 18,
+  orientation = "left",
+}: ChevronProps) => {
+  return (
+    <div className={`flex items-center justify-center ${className ?? ""}`}>
+      {orientation === "left" && (
+        <IcArrowLeft width={size} height={size} className="text-neutral-60" />
+      )}
+      {orientation === "right" && (
+        <IcArrowRight width={size} height={size} className="text-neutral-60" />
+      )}
+    </div>
+  );
+};
+
+// function _CustomCaption({
+//   displayMonth,
+//   onMonthChange,
+//   className,
+// }: CaptionProps) {
+//   const year = displayMonth.getFullYear();
+//   const month = displayMonth.getMonth(); // 0-based
+
+//   const prevMonth = () => {
+//     const prev = new Date(year, month - 1);
+//     onMonthChange(prev);
+//   };
+//   const nextMonth = () => {
+//     const next = new Date(year, month + 1);
+//     onMonthChange(next);
+//   };
+
+//   return (
+//     <div className={`${className} flex items-center justify-between px-4 py-2`}>
+//       <button
+//         type="button"
+//         onClick={prevMonth}
+//         className="flex items-center justify-center p-1"
+//         aria-label="Previous month"
+//       >
+//         <IcArrowLeft className="h-5 w-5 text-neutral-60" />
+//       </button>
+
+//       <div className="text-body1-medi16 text-neutral-20">
+//         {year}년 {month + 1}월
+//       </div>
+
+//       <button
+//         type="button"
+//         onClick={nextMonth}
+//         className="flex items-center justify-center p-1"
+//         aria-label="Next month"
+//       >
+//         <IcArrowRight className="h-5 w-5 text-neutral-60" />
+//       </button>
+//     </div>
+//   );
+// }
+
+export default Calendar;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -260,6 +260,9 @@ importers:
       react:
         specifier: ^19.1.0
         version: 19.1.0
+      react-day-picker:
+        specifier: ^9.8.1
+        version: 9.8.1(react@19.1.0)
       react-dom:
         specifier: ^19.1.0
         version: 19.1.0(react@19.1.0)
@@ -1255,6 +1258,9 @@ packages:
   '@csstools/css-tokenizer@3.0.4':
     resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
     engines: {node: '>=18'}
+
+  '@date-fns/tz@1.3.1':
+    resolution: {integrity: sha512-LnBOyuj+piItX/D5BWBSckBsuZyOt7Jg2obGNiObq7qjl1A2/8F+i4RS8/MmkSdnw6hOe6afrJLCWrUWZw5Mlw==}
 
   '@dnd-kit/accessibility@3.1.1':
     resolution: {integrity: sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw==}
@@ -4331,6 +4337,12 @@ packages:
     resolution: {integrity: sha512-BS8PfmtDGnrgYdOonGZQdLZslWIeCGFP9tpan0hi1Co2Zr2NKADsvGYA8XxuG/4UWgJ6Cjtv+YJnB6MM69QGlQ==}
     engines: {node: '>= 0.4'}
 
+  date-fns-jalali@4.1.0-0:
+    resolution: {integrity: sha512-hTIP/z+t+qKwBDcmmsnmjWTduxCg+5KfdqWQvb2X/8C9+knYY6epN/pfxdDuyVlSVeFz0sM5eEfwIUQ70U4ckg==}
+
+  date-fns@4.1.0:
+    resolution: {integrity: sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==}
+
   dateformat@4.6.3:
     resolution: {integrity: sha512-2P0p0pFGzHS5EMnhdxQi7aJN+iMheud0UhG4dlE1DLAlvL8JHjJJTX/CSm4JXwV0Ka5nGk3zC5mcb5bUQUxxMA==}
 
@@ -6341,6 +6353,12 @@ packages:
   rc@1.2.8:
     resolution: {integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==}
     hasBin: true
+
+  react-day-picker@9.8.1:
+    resolution: {integrity: sha512-kMcLrp3PfN/asVJayVv82IjF3iLOOxuH5TNFWezX6lS/T8iVRFPTETpHl3TUSTH99IDMZLubdNPJr++rQctkEw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      react: '>=16.8.0'
 
   react-docgen-typescript@2.4.0:
     resolution: {integrity: sha512-ZtAp5XTO5HRzQctjPU0ybY0RRCQO19X/8fxn3w7y2VVTUbGHDKULPTL4ky3vB05euSgG5NpALhEhDPvQ56wvXg==}
@@ -8806,6 +8824,8 @@ snapshots:
       '@csstools/css-tokenizer': 3.0.4
 
   '@csstools/css-tokenizer@3.0.4': {}
+
+  '@date-fns/tz@1.3.1': {}
 
   '@dnd-kit/accessibility@3.1.1(react@19.1.0)':
     dependencies:
@@ -12020,6 +12040,10 @@ snapshots:
       es-errors: 1.3.0
       is-data-view: 1.0.2
 
+  date-fns-jalali@4.1.0-0: {}
+
+  date-fns@4.1.0: {}
+
   dateformat@4.6.3: {}
 
   de-indent@1.0.2: {}
@@ -14157,6 +14181,13 @@ snapshots:
       ini: 1.3.8
       minimist: 1.2.8
       strip-json-comments: 2.0.1
+
+  react-day-picker@9.8.1(react@19.1.0):
+    dependencies:
+      '@date-fns/tz': 1.3.1
+      date-fns: 4.1.0
+      date-fns-jalali: 4.1.0-0
+      react: 19.1.0
 
   react-docgen-typescript@2.4.0(typescript@5.8.3):
     dependencies:


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- Date picker 컴포넌트를 구현했습니다 
- 최대한 mvp 기능 빨리 마무리하고.. 후속 pr로 월과 년도 부분도 커스텀 컴포넌트로 구성하도록 하겠습니다. 
(현재는 react-day-picker 에서 제공하는 드롭다운으로 대체한상태입니다.  )

- 년도와 월 선택의 경우, 와이어프레임상 월과 년도 역시 다중선택이 되도록 나와있는데, 그에 따른 기능 명세가 확실하지 않아 이부분 수요일 회의에서 질문드릴 예정입니다. 
[월 / 년도 다중선택에 따른 case 분류]
(Ex. 8 - 10월 선택시 ->  8월 1일- 10월 30일이 자동으로 선택되는건지) 
(Ex. 2023 - 2024년 선택시 ->  2023년 1월 1일 - 2024년 12월 31일 선택되는건지?) 


## ✅ 체크리스트

- [ ] 기능 동작 확인
- [ ] 코드 리뷰 반영
- [ ] 테스트 통과
- [ ] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->
https://github.com/user-attachments/assets/0843bf83-56c3-408d-bcc8-6f226f1ce28b


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->
