### PR TITLE
[Y26W2-299] fix(web): tripBoardId 변경에 따른 빌드 오류 수정

### DIFF
--- a/apps/web/src/domains/compare/hooks/use-comparison-table.ts
+++ b/apps/web/src/domains/compare/hooks/use-comparison-table.ts
@@ -30,7 +30,7 @@ export const useComparisonTable = ({
   const formData = useMemo((): ComparisonFormData => {
     const response = data?.data.result;
     if (!response) {
-      return { boardId, accommodationRequestList: [] };
+      return { tripBoardId: boardId, accommodationRequestList: [] };
     }
     return transformComparisonTableResponseToFormData({ boardId, response });
   }, [data, boardId]);

--- a/apps/web/src/domains/compare/utils/form.ts
+++ b/apps/web/src/domains/compare/utils/form.ts
@@ -21,7 +21,7 @@ export const transformComparisonTableResponseToFormData = ({
   };
 
   return {
-    boardId,
+    tripBoardId: boardId,
     tableName: response.tableName,
     accommodationRequestList:
       response.accommodationResponsesList?.map(


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 비교표 로직쪽 `boardId` 로 작성된 부분을 `tripBoardId` 로 수정하였습니다.
별칭 사용하여, 받아주는 쪽에서만 `tripBoardId`로 받아서 `boardId`로 return 하였기 때문에 hook 부분만 수정했습니다! 

## ✅ 체크리스트

- [x] 기능 동작 확인
- [ ] 코드 리뷰 반영
- [ ] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 비교 테이블에서 검색 결과가 없을 때도 여행 보드 ID가 올바르게 유지되어 폼과 후속 단계가 중단되지 않도록 개선했습니다.
  - 화면 간 보드 식별자 표기의 불일치를 해소하여 필터, 공유 등 관련 기능이 보다 안정적으로 동작합니다.
  - 사용자 입력 복원·재시도 시 식별자 손실로 인한 간헐적 오류 가능성을 줄였습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->