### PR TITLE
[Y26W2-302] feat(ui): Popup 컴포넌트 개발

### DIFF
--- a/packages/ui/src/components/popup/index.stories.tsx
+++ b/packages/ui/src/components/popup/index.stories.tsx
@@ -1,0 +1,64 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { Button } from "@/components/button";
+import { Popup } from "./index";
+
+const meta: Meta<typeof Popup> = {
+  title: "Components/Popup",
+  component: Popup,
+  parameters: {
+    layout: "centered",
+  },
+  decorators: [
+    (Story) => (
+      <div className="flex h-[60rem] w-[60rem] items-center justify-center">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+export default meta;
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {
+  args: {
+    onClose: () => console.log("Close clicked"),
+    className: "w-full max-w-[40rem]",
+    children: (
+      <div className="flex flex-col gap-[2.4rem]">
+        <p className="text-body1-regular16 text-neutral-30">
+          팝업 타이틀이 없는 팝업입니다.
+        </p>
+        <Button
+          variant="primary"
+          size="lg"
+          className="flex w-full justify-center"
+        >
+          확인
+        </Button>
+      </div>
+    ),
+  },
+};
+
+export const WithTitle: Story = {
+  args: {
+    title: "타이틀",
+    onClose: () => console.log("Close clicked"),
+    className: "w-full max-w-[40rem]",
+    children: (
+      <div className="flex flex-col gap-[2.4rem]">
+        <p className="text-body1-regular16 text-neutral-30">
+          팝업 타이틀이 있는 팝업입니다.
+        </p>
+        <Button
+          variant="primary"
+          size="lg"
+          className="flex w-full justify-center"
+        >
+          확인
+        </Button>
+      </div>
+    ),
+  },
+};

--- a/packages/ui/src/components/popup/index.tsx
+++ b/packages/ui/src/components/popup/index.tsx
@@ -1,0 +1,37 @@
+import type { PropsWithChildren } from "react";
+import { IcClose } from "@/index";
+import { cn } from "@/utils";
+
+type PopupProps = PropsWithChildren<{
+  title?: string;
+  onClose: () => void;
+  className?: string;
+}>;
+
+export const Popup = ({ title, children, onClose, className }: PopupProps) => {
+  return (
+    <div
+      className={cn(
+        "flex flex-col rounded-[1.6rem] border border-neutral-90 bg-white p-[2.4rem]",
+        className,
+      )}
+    >
+      <div className="mb-[2.4rem] flex items-start justify-between">
+        {title && (
+          <h2 className="text-heading1-semi20 text-neutral-25">{title}</h2>
+        )}
+        <button
+          type="button"
+          onClick={onClose}
+          className={cn(
+            "cursor-pointer rounded-[0.8rem] transition-colors hover:bg-neutral-90",
+            !title && "ml-auto",
+          )}
+        >
+          <IcClose className="h-[3rem] w-[3rem] text-neutral-40" />
+        </button>
+      </div>
+      <div className="flex-1">{children}</div>
+    </div>
+  );
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -64,6 +64,7 @@ export { SolidExpand } from "@/components/icon-button/solid-expand";
 export type { IconTabsOption, IconTabsProps } from "@/components/icon-tabs";
 export { IconTabs } from "@/components/icon-tabs";
 export { Pin } from "@/components/pin";
+export { Popup } from "@/components/popup";
 export { TextField } from "@/components/text-field";
 export { Textarea } from "@/components/textarea";
 export { TimePicker } from "@/components/time-picker";


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- Popup 컴포넌트를 개발했습니다.
- 실제 상태 관리 (popup의 on/off 등) 는 외부에서 주입합니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

| without title | with title |
| - | - |
| <img width="433" height="225" alt="CleanShot 2025-08-14 at 01 58 43" src="https://github.com/user-attachments/assets/21903239-2c44-4168-be98-88414399383b" /> | <img width="427" height="221" alt="CleanShot 2025-08-14 at 01 59 14" src="https://github.com/user-attachments/assets/753348b4-fb50-44da-937d-04cfd0f56122" /> |


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
commit-id:3698c491

---

**Stack**:
- #125
- #124
- #123
- #121
- #120 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **신기능**
  * 새로운 팝업 컴포넌트를 추가했습니다. 선택적 제목, 닫기 버튼(콜백 지원), 내용 영역을 포함하며 className으로 레이아웃/크기 조절이 가능합니다.
  * UI 패키지의 공개 API에 Popup이 포함되어 바로 사용할 수 있습니다.

* **문서**
  * 스토리북에 기본(제목 없음)과 제목 있는 예시를 추가했습니다. 중앙 정렬된 캔버스에서 동작과 레이아웃(한국어 예시 텍스트 및 확인 버튼)을 확인할 수 있습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->