### PR TITLE
[Y26W2-302] feat(ui): 누락된 Next.js svgr 타입 설정 추가

### DIFF
--- a/apps/web/src/types/svgr.d.ts
+++ b/apps/web/src/types/svgr.d.ts
@@ -1,0 +1,5 @@
+declare module "*.svg" {
+  import type { FC, SVGProps } from "react";
+  const content: FC<SVGProps<SVGElement>>;
+  export default content;
+}

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -12,6 +12,7 @@
     "**/*.ts",
     "**/*.tsx",
     ".next/types/**/*.ts",
+    "src/types/*.d.ts",
     "vitest.config.mts"
   ],
   "exclude": ["node_modules"]


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- `svgr` 타입 `.d.ts` 파일을 추가해서 빌드, 개발 과정에서 `svg` import를 사용할 수 있도록 구현했습니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
commit-id:ce78f024

---

**Stack**:
- #125
- #124 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - SVG 파일을 React 컴포넌트로 사용할 수 있도록 타입 선언을 추가했습니다.
  - TypeScript 설정에 타입 선언 경로를 포함하도록 업데이트했습니다.
- **기타**
  - 사용자에게 보이는 기능 변화나 UI 변경은 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->