### PR TITLE
[Y26W2-307] feat(ui): UI 라이브러리 SSR 오류 수정

### DIFF
--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,7 +7,151 @@
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
-    "./app.css": "./dist/app.css"
+    "./app.css": "./dist/app.css",
+    "./components/action-card": {
+      "import": "./dist/components/action-card.js",
+      "types": "./dist/components/action-card.d.ts"
+    },
+    "./components/action-option": {
+      "import": "./dist/components/action-option.js",
+      "types": "./dist/components/action-option.d.ts"
+    },
+    "./components/avatar-profile": {
+      "import": "./dist/components/avatar-profile.js",
+      "types": "./dist/components/avatar-profile.d.ts"
+    },
+    "./components/avatar-profile-group": {
+      "import": "./dist/components/avatar-profile-group.js",
+      "types": "./dist/components/avatar-profile-group.d.ts"
+    },
+    "./components/button/button.variant": {
+      "import": "./dist/components/button/button.variant.js",
+      "types": "./dist/components/button/button.variant.d.ts"
+    },
+    "./components/button": {
+      "import": "./dist/components/button.js",
+      "types": "./dist/components/button.d.ts"
+    },
+    "./components/calendar": {
+      "import": "./dist/components/calendar.js",
+      "types": "./dist/components/calendar.d.ts"
+    },
+    "./components/card/card.utils": {
+      "import": "./dist/components/card/card.utils.js",
+      "types": "./dist/components/card/card.utils.d.ts"
+    },
+    "./components/card/card.variant": {
+      "import": "./dist/components/card/card.variant.js",
+      "types": "./dist/components/card/card.variant.d.ts"
+    },
+    "./components/card": {
+      "import": "./dist/components/card.js",
+      "types": "./dist/components/card.d.ts"
+    },
+    "./components/chip/chip.variant": {
+      "import": "./dist/components/chip/chip.variant.js",
+      "types": "./dist/components/chip/chip.variant.d.ts"
+    },
+    "./components/chip": {
+      "import": "./dist/components/chip.js",
+      "types": "./dist/components/chip.d.ts"
+    },
+    "./components/confirm": {
+      "import": "./dist/components/confirm.js",
+      "types": "./dist/components/confirm.d.ts"
+    },
+    "./components/graph": {
+      "import": "./dist/components/graph.js",
+      "types": "./dist/components/graph.d.ts"
+    },
+    "./components/icon-button/add-icon-button/add-icon-button.variant": {
+      "import": "./dist/components/icon-button/add-icon-button/add-icon-button.variant.js",
+      "types": "./dist/components/icon-button/add-icon-button/add-icon-button.variant.d.ts"
+    },
+    "./components/icon-button/add-icon-button": {
+      "import": "./dist/components/icon-button/add-icon-button.js",
+      "types": "./dist/components/icon-button/add-icon-button.d.ts"
+    },
+    "./components/icon-button/check-icon-button/check-icon-button.variant": {
+      "import": "./dist/components/icon-button/check-icon-button/check-icon-button.variant.js",
+      "types": "./dist/components/icon-button/check-icon-button/check-icon-button.variant.d.ts"
+    },
+    "./components/icon-button/check-icon-button": {
+      "import": "./dist/components/icon-button/check-icon-button.js",
+      "types": "./dist/components/icon-button/check-icon-button.d.ts"
+    },
+    "./components/icon-button/delete-icon-button": {
+      "import": "./dist/components/icon-button/delete-icon-button.js",
+      "types": "./dist/components/icon-button/delete-icon-button.d.ts"
+    },
+    "./components/icon-button/floating-icon-button": {
+      "import": "./dist/components/icon-button/floating-icon-button.js",
+      "types": "./dist/components/icon-button/floating-icon-button.d.ts"
+    },
+    "./components/icon-button/normal-icon-button": {
+      "import": "./dist/components/icon-button/normal-icon-button.js",
+      "types": "./dist/components/icon-button/normal-icon-button.d.ts"
+    },
+    "./components/icon-button/normal-icon-button/normal-icon-button.variant": {
+      "import": "./dist/components/icon-button/normal-icon-button/normal-icon-button.variant.js",
+      "types": "./dist/components/icon-button/normal-icon-button/normal-icon-button.variant.d.ts"
+    },
+    "./components/icon-button/solid-expand": {
+      "import": "./dist/components/icon-button/solid-expand.js",
+      "types": "./dist/components/icon-button/solid-expand.d.ts"
+    },
+    "./components/icon-tabs": {
+      "import": "./dist/components/icon-tabs.js",
+      "types": "./dist/components/icon-tabs.d.ts"
+    },
+    "./components/image-card": {
+      "import": "./dist/components/image-card.js",
+      "types": "./dist/components/image-card.d.ts"
+    },
+    "./components/pin": {
+      "import": "./dist/components/pin.js",
+      "types": "./dist/components/pin.d.ts"
+    },
+    "./components/popup": {
+      "import": "./dist/components/popup.js",
+      "types": "./dist/components/popup.d.ts"
+    },
+    "./components/text-field": {
+      "import": "./dist/components/text-field.js",
+      "types": "./dist/components/text-field.d.ts"
+    },
+    "./components/text-with-icon": {
+      "import": "./dist/components/text-with-icon.js",
+      "types": "./dist/components/text-with-icon.d.ts"
+    },
+    "./components/textarea": {
+      "import": "./dist/components/textarea.js",
+      "types": "./dist/components/textarea.d.ts"
+    },
+    "./components/time-picker": {
+      "import": "./dist/components/time-picker.js",
+      "types": "./dist/components/time-picker.d.ts"
+    },
+    "./components/travel-board": {
+      "import": "./dist/components/travel-board.js",
+      "types": "./dist/components/travel-board.d.ts"
+    },
+    "./hooks/use-floating": {
+      "import": "./dist/hooks/use-floating.js",
+      "types": "./dist/hooks/use-floating.d.ts"
+    },
+    "./index": {
+      "import": "./dist/index.js",
+      "types": "./dist/index.d.ts"
+    },
+    "./utils/date": {
+      "import": "./dist/utils/date.js",
+      "types": "./dist/utils/date.d.ts"
+    },
+    "./utils": {
+      "import": "./dist/utils.js",
+      "types": "./dist/utils.d.ts"
+    }
   },
   "types": "dist/index.d.ts",
   "scripts": {
@@ -55,6 +199,7 @@
     "playwright": "^1.52.0",
     "postcss": "^8",
     "postcss-load-config": "*",
+    "rollup-preserve-directives": "^1.1.3",
     "storybook": "^9.0.6",
     "tailwindcss": "^4.1.7",
     "typescript": "^5.8.3",

--- a/packages/ui/src/components/time-picker/index.tsx
+++ b/packages/ui/src/components/time-picker/index.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { cva, type VariantProps } from "class-variance-authority";
 import { type ComponentProps, type KeyboardEvent, useState } from "react";
 import { useOutsideClickEffect } from "react-simplikit";

--- a/packages/ui/src/components/travel-board/index.tsx
+++ b/packages/ui/src/components/travel-board/index.tsx
@@ -1,3 +1,4 @@
+"use client";
 import { useRef, useState } from "react";
 import { useOutsideClickEffect } from "react-simplikit";
 import IcBookmark from "@/assets/icons/ic_bookmark.svg?react";

--- a/packages/ui/src/hooks/use-floating.tsx
+++ b/packages/ui/src/hooks/use-floating.tsx
@@ -1,3 +1,4 @@
+"use client";
 import {
   type CSSProperties,
   type RefObject,

--- a/packages/ui/vite.config.mts
+++ b/packages/ui/vite.config.mts
@@ -1,6 +1,7 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
 import react from "@vitejs/plugin-react";
+import preserveDirectives from "rollup-preserve-directives";
 import type { Plugin } from "vite";
 import { defineConfig } from "vite";
 import dts from "vite-plugin-dts";
@@ -31,6 +32,7 @@ export default defineConfig({
       rollupTypes: true,
     }),
     tsconfigPaths(),
+    preserveDirectives(),
     externalizeDeps(),
   ],
   build: {
@@ -41,11 +43,12 @@ export default defineConfig({
     },
     rollupOptions: {
       output: {
+        entryFileNames: "index.js",
         globals: {
           react: "React",
           "react-dom": "ReactDOM",
         },
-        entryFileNames: "index.js",
+        preserveModules: true,
       },
     },
     sourcemap: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -344,6 +344,9 @@ importers:
       postcss-load-config:
         specifier: '*'
         version: 6.0.1(jiti@2.4.2)(postcss@8.5.6)(yaml@2.8.0)
+      rollup-preserve-directives:
+        specifier: ^1.1.3
+        version: 1.1.3(rollup@4.44.2)
       storybook:
         specifier: ^9.0.6
         version: 9.0.15(@testing-library/dom@10.4.0)
@@ -6695,6 +6698,11 @@ packages:
 
   rfdc@1.4.1:
     resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rollup-preserve-directives@1.1.3:
+    resolution: {integrity: sha512-oXqxd6ZzkoQej8Qt0k+S/yvO2+S4CEVEVv2g85oL15o0cjAKTKEuo2MzyA8FcsBBXbtytBzBMFAbhvQg4YyPUQ==}
+    peerDependencies:
+      rollup: ^2.0.0 || ^3.0.0 || ^4.0.0
 
   rollup@4.35.0:
     resolution: {integrity: sha512-kg6oI4g+vc41vePJyO6dHt/yl0Rz3Thv0kJeVQ3D1kS3E5XSuKbPc29G4IpT/Kv1KQwgHVcN+HtyS+HYLNSvQg==}
@@ -14642,6 +14650,11 @@ snapshots:
   reusify@1.1.0: {}
 
   rfdc@1.4.1: {}
+
+  rollup-preserve-directives@1.1.3(rollup@4.44.2):
+    dependencies:
+      magic-string: 0.30.17
+      rollup: 4.44.2
 
   rollup@4.35.0:
     dependencies:


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->

| | |
| - | - |
| <img width="1072" height="429" alt="7601" src="https://github.com/user-attachments/assets/bf691bbb-5894-43fe-8d83-3b6f1ca0a442" /> | <img width="982" height="736" alt="92030" src="https://github.com/user-attachments/assets/4505c2e1-a1ae-4d2c-bd69-ed818511bcf6" /> |

SSR 과정에서 `@ssok/ui` 패키지를 import 하는 코드가 존재하기만 해도 문제가 되어서, 이를 수정하는 개선 사항입니다.

module 구조를 유지하기 위해서 (keep module)번들을 쪼개고

<img width="520" height="208" alt="image" src="https://github.com/user-attachments/assets/fa9e8ac7-e080-4695-8d71-f8f1d3b90cb0" />

`use client`를 실제 필요한 모듈들에 달아서 문제를 해결했습니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
commit-id:eacca285

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * UI 패키지 공개 API 확장: 개별 컴포넌트·유틸·훅을 경로별로 직접 임포트 가능.
  * 버튼/아이콘버튼/카드/칩/캘린더/이미지카드/그래프/탭/텍스트필드/텍스트+아이콘/텍스트에어리어/타임피커/트래블보드 등 다수 컴포넌트와 utils/date, hooks/use-floating 경로 추가.
  * 타임피커, 트래블보드, use-floating 훅이 클라이언트 컴포넌트로 동작하도록 표시.
* 작업
  * 빌드 구성 개선: 지시문 보존, 모듈 보존 출력, 엔트리 파일명 정리.
  * 개발 의존성 추가.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->