### PR TITLE
[Y26W2-310] feat(api): OpenAPI 갱신, 스키마 수정

### DIFF
--- a/packages/api/src/api/openapi.json
+++ b/packages/api/src/api/openapi.json
@@ -9,6 +9,7 @@
     { "url": "https://api.ssok.info", "description": "Generated server url" }
   ],
   "tags": [
+    { "name": "USER API", "description": "사용자 관련 API" },
     { "name": "숙소 API", "description": "숙소 관련 API" },
     { "name": "OAUTH API", "description": "소셜 로그인 API" },
     { "name": "비교표 API", "description": "비교표 관련 API" },
@@ -178,6 +179,74 @@
         },
         "security": [{ "JWT": [] }]
       },
+      "delete": {
+        "tags": ["비교표 API"],
+        "summary": "비교표 삭제",
+        "description": "사용자가 생성한 비교표를 삭제합니다. 생성자만 삭제할 수 있습니다. (Authorization 헤더에 Bearer 토큰 필요)",
+        "operationId": "deleteComparisonTable",
+        "parameters": [
+          {
+            "name": "tableId",
+            "in": "path",
+            "description": "삭제할 비교표의 ID",
+            "required": true,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "비교표 삭제 성공",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardResponseComparisonTableDeleteResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "인증 실패 - 유효하지 않은 토큰 또는 인증 정보 없음",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardResponseComparisonTableDeleteResponse"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "권한 없음 - 비교표 생성자가 아님",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardResponseComparisonTableDeleteResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "비교표를 찾을 수 없음",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardResponseComparisonTableDeleteResponse"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "서버 내부 오류 - 비교표 삭제 중 오류 발생",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardResponseComparisonTableDeleteResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [{ "JWT": [] }]
+      },
       "patch": {
         "tags": ["비교표 API"],
         "summary": "비교표 숙소 추가",
@@ -335,6 +404,44 @@
         "security": [{ "JWT": [] }]
       }
     },
+    "/api/oauth/refresh": {
+      "post": {
+        "tags": ["OAUTH API"],
+        "summary": "리프레시 토큰 재발급",
+        "description": "유효한 리프레시 토큰을 사용하여 새로운 액세스 토큰과 리프레시 토큰을 발급받습니다. 기존 리프레시 토큰은 무효화되고 새로운 토큰 쌍이 생성됩니다. 토큰 회전(Token Rotation)을 통해 보안을 강화합니다. 이 API는 액세스 토큰이 만료된 상황에서 사용되므로 JWT 인증이 필요하지 않습니다.",
+        "operationId": "refreshTokens",
+        "requestBody": {
+          "content": {
+            "application/json": {
+              "schema": { "$ref": "#/components/schemas/RefreshTokenRequest" }
+            }
+          },
+          "required": true
+        },
+        "responses": {
+          "200": {
+            "description": "새로운 토큰이 성공적으로 발급되었습니다.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardResponseTokenSuccessResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "리프레시 토큰이 유효하지 않거나 만료되었습니다.",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardResponseTokenSuccessResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
     "/api/oauth/logout": {
       "post": {
         "tags": ["OAUTH API"],
@@ -475,6 +582,47 @@
               "*/*": {
                 "schema": {
                   "$ref": "#/components/schemas/StandardResponseInvitationToggleResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [{ "JWT": [] }]
+      }
+    },
+    "/api/users/me": {
+      "get": {
+        "tags": ["USER API"],
+        "summary": "사용자 정보 조회",
+        "description": "현재 로그인한 사용자의 기본 정보(닉네임, 프로필 이미지)를 조회합니다.",
+        "operationId": "getUserInfo",
+        "responses": {
+          "200": {
+            "description": "사용자 정보 조회 성공",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardResponseUserInfoResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "인증되지 않은 사용자",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardResponseUserInfoResponse"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "사용자를 찾을 수 없음 또는 탈퇴한 사용자",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardResponseUserInfoResponse"
                 }
               }
             }
@@ -1102,6 +1250,51 @@
         "type": "object",
         "properties": { "withdrawSuccess": { "type": "boolean" } }
       },
+      "RefreshTokenRequest": {
+        "type": "object",
+        "description": "리프레시 토큰 재발급 요청",
+        "properties": {
+          "refreshToken": {
+            "type": "string",
+            "description": "리프레시 토큰",
+            "minLength": 1
+          }
+        }
+      },
+      "StandardResponseTokenSuccessResponse": {
+        "type": "object",
+        "description": "API 응답의 표준 형식을 정의하는 클래스",
+        "properties": {
+          "responseType": {
+            "type": "string",
+            "description": "응답 유형",
+            "enum": ["SUCCESS", "ERROR"],
+            "example": "SUCCESS"
+          },
+          "result": {
+            "$ref": "#/components/schemas/TokenSuccessResponse",
+            "description": "응답 결과 데이터"
+          }
+        }
+      },
+      "TokenSuccessResponse": {
+        "type": "object",
+        "description": "토큰 발급 응답",
+        "properties": {
+          "accessToken": {
+            "type": "string",
+            "description": "액세스 토큰",
+            "example": "access-token-example",
+            "readOnly": true
+          },
+          "refreshToken": {
+            "type": "string",
+            "description": "리프레시 토큰",
+            "example": "refresh-token-example",
+            "readOnly": true
+          }
+        }
+      },
       "LogoutResponse": {
         "type": "object",
         "properties": { "logoutSuccess": { "type": "boolean" } }
@@ -1126,9 +1319,21 @@
         "type": "object",
         "description": "OAuth 로그인 응답",
         "properties": {
-          "userId": { "type": "integer", "format": "int64" },
-          "nickname": { "type": "string" },
-          "token": { "$ref": "#/components/schemas/TokenSuccessResponse" }
+          "userId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "사용자 ID",
+            "example": 12345
+          },
+          "nickname": {
+            "type": "string",
+            "description": "사용자 닉네임",
+            "example": "홍길동"
+          },
+          "token": {
+            "$ref": "#/components/schemas/TokenSuccessResponse",
+            "description": "토큰 정보"
+          }
         }
       },
       "StandardResponseOauthLoginResponse": {
@@ -1145,13 +1350,6 @@
             "$ref": "#/components/schemas/OauthLoginResponse",
             "description": "응답 결과 데이터"
           }
-        }
-      },
-      "TokenSuccessResponse": {
-        "type": "object",
-        "properties": {
-          "accessToken": { "type": "string" },
-          "refreshToken": { "type": "string" }
         }
       },
       "CreateComparisonTableRequest": {
@@ -1388,6 +1586,38 @@
           "distance": { "type": "string" },
           "byFoot": { "$ref": "#/components/schemas/DistanceInfo" },
           "byCar": { "$ref": "#/components/schemas/DistanceInfo" }
+        }
+      },
+      "StandardResponseUserInfoResponse": {
+        "type": "object",
+        "description": "API 응답의 표준 형식을 정의하는 클래스",
+        "properties": {
+          "responseType": {
+            "type": "string",
+            "description": "응답 유형",
+            "enum": ["SUCCESS", "ERROR"],
+            "example": "SUCCESS"
+          },
+          "result": {
+            "$ref": "#/components/schemas/UserInfoResponse",
+            "description": "응답 결과 데이터"
+          }
+        }
+      },
+      "UserInfoResponse": {
+        "type": "object",
+        "description": "유저 정보 응답",
+        "properties": {
+          "nickname": {
+            "type": "string",
+            "description": "유저 닉네임",
+            "example": "홍길동"
+          },
+          "profileImageUrl": {
+            "type": "string",
+            "description": "유저 프로필 이미지 URL",
+            "example": "https://example.com/profile/user123.jpg"
+          }
         }
       },
       "ParticipantProfileResponse": {
@@ -1690,6 +1920,29 @@
         "type": "object",
         "properties": {
           "tripBoardId": { "type": "integer", "format": "int64" }
+        }
+      },
+      "ComparisonTableDeleteResponse": {
+        "type": "object",
+        "properties": {
+          "tableId": { "type": "integer", "format": "int64" },
+          "message": { "type": "string" }
+        }
+      },
+      "StandardResponseComparisonTableDeleteResponse": {
+        "type": "object",
+        "description": "API 응답의 표준 형식을 정의하는 클래스",
+        "properties": {
+          "responseType": {
+            "type": "string",
+            "description": "응답 유형",
+            "enum": ["SUCCESS", "ERROR"],
+            "example": "SUCCESS"
+          },
+          "result": {
+            "$ref": "#/components/schemas/ComparisonTableDeleteResponse",
+            "description": "응답 결과 데이터"
+          }
         }
       },
       "AccommodationDeleteResponse": {

--- a/packages/api/src/index.msw.ts
+++ b/packages/api/src/index.msw.ts
@@ -19,12 +19,14 @@ import type {
   StandardResponseAuthorizeUrlResponse,
   StandardResponseBoolean,
   StandardResponseComparisonFactorList,
+  StandardResponseComparisonTableDeleteResponse,
   StandardResponseComparisonTableResponse,
   StandardResponseCreateComparisonTableResponse,
   StandardResponseInvitationCodeResponse,
   StandardResponseInvitationToggleResponse,
   StandardResponseLogoutResponse,
   StandardResponseOauthLoginResponse,
+  StandardResponseTokenSuccessResponse,
   StandardResponseTripBoardCreateResponse,
   StandardResponseTripBoardDeleteResponse,
   StandardResponseTripBoardJoinResponse,
@@ -32,6 +34,7 @@ import type {
   StandardResponseTripBoardPageResponse,
   StandardResponseTripBoardSummaryResponse,
   StandardResponseTripBoardUpdateResponse,
+  StandardResponseUserInfoResponse,
   StandardResponseWithdrawResponse,
 } from "./index.schemas";
 
@@ -564,6 +567,33 @@ export const getUpdateComparisonTableResponseMock = (
   ...overrideResponse,
 });
 
+export const getDeleteComparisonTableResponseMock = (
+  overrideResponse: Partial<StandardResponseComparisonTableDeleteResponse> = {},
+): StandardResponseComparisonTableDeleteResponse => ({
+  responseType: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(["SUCCESS", "ERROR"] as const),
+    undefined,
+  ]),
+  result: faker.helpers.arrayElement([
+    {
+      tableId: faker.helpers.arrayElement([
+        faker.number.int({
+          min: undefined,
+          max: undefined,
+          multipleOf: undefined,
+        }),
+        undefined,
+      ]),
+      message: faker.helpers.arrayElement([
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
+        undefined,
+      ]),
+    },
+    undefined,
+  ]),
+  ...overrideResponse,
+});
+
 export const getAddAccommodationToComparisonTableResponseMock = (
   overrideResponse: Partial<StandardResponseComparisonTableResponse> = {},
 ): StandardResponseComparisonTableResponse => ({
@@ -1090,6 +1120,29 @@ export const getWithdrawUserResponseMock = (
   ...overrideResponse,
 });
 
+export const getRefreshTokensResponseMock = (
+  overrideResponse: Partial<StandardResponseTokenSuccessResponse> = {},
+): StandardResponseTokenSuccessResponse => ({
+  responseType: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(["SUCCESS", "ERROR"] as const),
+    undefined,
+  ]),
+  result: faker.helpers.arrayElement([
+    {
+      accessToken: faker.helpers.arrayElement([
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
+        undefined,
+      ]),
+      refreshToken: faker.helpers.arrayElement([
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
+        undefined,
+      ]),
+    },
+    undefined,
+  ]),
+  ...overrideResponse,
+});
+
 export const getLogoutResponseMock = (
   overrideResponse: Partial<StandardResponseLogoutResponse> = {},
 ): StandardResponseLogoutResponse => ({
@@ -1217,6 +1270,29 @@ export const getToggleInvitationActiveResponseMock = (
         undefined,
       ]),
       invitationCode: faker.helpers.arrayElement([
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
+        undefined,
+      ]),
+    },
+    undefined,
+  ]),
+  ...overrideResponse,
+});
+
+export const getGetUserInfoResponseMock = (
+  overrideResponse: Partial<StandardResponseUserInfoResponse> = {},
+): StandardResponseUserInfoResponse => ({
+  responseType: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(["SUCCESS", "ERROR"] as const),
+    undefined,
+  ]),
+  result: faker.helpers.arrayElement([
+    {
+      nickname: faker.helpers.arrayElement([
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
+        undefined,
+      ]),
+      profileImageUrl: faker.helpers.arrayElement([
         faker.string.alpha({ length: { min: 10, max: 20 } }),
         undefined,
       ]),
@@ -2252,6 +2328,31 @@ export const getUpdateComparisonTableMockHandler = (
   });
 };
 
+export const getDeleteComparisonTableMockHandler = (
+  overrideResponse?:
+    | StandardResponseComparisonTableDeleteResponse
+    | ((
+        info: Parameters<Parameters<typeof http.delete>[1]>[0],
+      ) =>
+        | Promise<StandardResponseComparisonTableDeleteResponse>
+        | StandardResponseComparisonTableDeleteResponse),
+) => {
+  return http.delete("*/api/comparison/:tableId", async (info) => {
+    await delay(500);
+
+    return new HttpResponse(
+      JSON.stringify(
+        overrideResponse !== undefined
+          ? typeof overrideResponse === "function"
+            ? await overrideResponse(info)
+            : overrideResponse
+          : getDeleteComparisonTableResponseMock(),
+      ),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+};
+
 export const getAddAccommodationToComparisonTableMockHandler = (
   overrideResponse?:
     | StandardResponseComparisonTableResponse
@@ -2371,6 +2472,31 @@ export const getWithdrawUserMockHandler = (
             ? await overrideResponse(info)
             : overrideResponse
           : getWithdrawUserResponseMock(),
+      ),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+};
+
+export const getRefreshTokensMockHandler = (
+  overrideResponse?:
+    | StandardResponseTokenSuccessResponse
+    | ((
+        info: Parameters<Parameters<typeof http.post>[1]>[0],
+      ) =>
+        | Promise<StandardResponseTokenSuccessResponse>
+        | StandardResponseTokenSuccessResponse),
+) => {
+  return http.post("*/api/oauth/refresh", async (info) => {
+    await delay(500);
+
+    return new HttpResponse(
+      JSON.stringify(
+        overrideResponse !== undefined
+          ? typeof overrideResponse === "function"
+            ? await overrideResponse(info)
+            : overrideResponse
+          : getRefreshTokensResponseMock(),
       ),
       { status: 200, headers: { "Content-Type": "application/json" } },
     );
@@ -2503,6 +2629,31 @@ export const getToggleInvitationActiveMockHandler = (
       );
     },
   );
+};
+
+export const getGetUserInfoMockHandler = (
+  overrideResponse?:
+    | StandardResponseUserInfoResponse
+    | ((
+        info: Parameters<Parameters<typeof http.get>[1]>[0],
+      ) =>
+        | Promise<StandardResponseUserInfoResponse>
+        | StandardResponseUserInfoResponse),
+) => {
+  return http.get("*/api/users/me", async (info) => {
+    await delay(500);
+
+    return new HttpResponse(
+      JSON.stringify(
+        overrideResponse !== undefined
+          ? typeof overrideResponse === "function"
+            ? await overrideResponse(info)
+            : overrideResponse
+          : getGetUserInfoResponseMock(),
+      ),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
 };
 
 export const getGetInvitationCodeMockHandler = (
@@ -2735,16 +2886,19 @@ export const getYapp26Web2Mock = () => [
   getDeleteTripBoardMockHandler(),
   getGetComparisonTableMockHandler(),
   getUpdateComparisonTableMockHandler(),
+  getDeleteComparisonTableMockHandler(),
   getAddAccommodationToComparisonTableMockHandler(),
   getCreateTripBoardMockHandler(),
   getLeaveTripBoardMockHandler(),
   getJoinTripBoardMockHandler(),
   getWithdrawUserMockHandler(),
+  getRefreshTokensMockHandler(),
   getLogoutMockHandler(),
   getExchangeKakaoTokenMockHandler(),
   getCreateComparisonTableMockHandler(),
   getRegisterAccommodationCardMockHandler(),
   getToggleInvitationActiveMockHandler(),
+  getGetUserInfoMockHandler(),
   getGetInvitationCodeMockHandler(),
   getGetTripBoardsMockHandler(),
   getGetKakaoAuthorizeUrlMockHandler(),

--- a/packages/api/src/index.schemas.ts
+++ b/packages/api/src/index.schemas.ts
@@ -271,6 +271,43 @@ export interface WithdrawResponse {
   withdrawSuccess?: boolean;
 }
 
+/**
+ * 리프레시 토큰 재발급 요청
+ */
+export interface RefreshTokenRequest {
+  /**
+   * 리프레시 토큰
+   * @minLength 1
+   */
+  refreshToken?: string;
+}
+
+/**
+ * 응답 유형
+ */
+export type StandardResponseTokenSuccessResponseResponseType =
+  | "SUCCESS"
+  | "ERROR";
+/**
+ * API 응답의 표준 형식을 정의하는 클래스
+ */
+export interface StandardResponseTokenSuccessResponse {
+  /** 응답 유형 */
+  responseType?: StandardResponseTokenSuccessResponseResponseType;
+  /** 응답 결과 데이터 */
+  result?: TokenSuccessResponse;
+}
+
+/**
+ * 토큰 발급 응답
+ */
+export interface TokenSuccessResponse {
+  /** 액세스 토큰 */
+  readonly accessToken?: string;
+  /** 리프레시 토큰 */
+  readonly refreshToken?: string;
+}
+
 export interface LogoutResponse {
   logoutSuccess?: boolean;
 }
@@ -293,8 +330,11 @@ export interface StandardResponseLogoutResponse {
  * OAuth 로그인 응답
  */
 export interface OauthLoginResponse {
+  /** 사용자 ID */
   userId?: number;
+  /** 사용자 닉네임 */
   nickname?: string;
+  /** 토큰 정보 */
   token?: TokenSuccessResponse;
 }
 
@@ -312,11 +352,6 @@ export interface StandardResponseOauthLoginResponse {
   responseType?: StandardResponseOauthLoginResponseResponseType;
   /** 응답 결과 데이터 */
   result?: OauthLoginResponse;
-}
-
-export interface TokenSuccessResponse {
-  accessToken?: string;
-  refreshToken?: string;
 }
 
 export interface CreateComparisonTableRequest {
@@ -502,6 +537,30 @@ export interface Transportation {
   distance?: string;
   byFoot?: DistanceInfo;
   byCar?: DistanceInfo;
+}
+
+/**
+ * 응답 유형
+ */
+export type StandardResponseUserInfoResponseResponseType = "SUCCESS" | "ERROR";
+/**
+ * API 응답의 표준 형식을 정의하는 클래스
+ */
+export interface StandardResponseUserInfoResponse {
+  /** 응답 유형 */
+  responseType?: StandardResponseUserInfoResponseResponseType;
+  /** 응답 결과 데이터 */
+  result?: UserInfoResponse;
+}
+
+/**
+ * 유저 정보 응답
+ */
+export interface UserInfoResponse {
+  /** 유저 닉네임 */
+  nickname?: string;
+  /** 유저 프로필 이미지 URL */
+  profileImageUrl?: string;
 }
 
 export type ParticipantProfileResponseRole = "OWNER" | "MEMBER";
@@ -752,6 +811,27 @@ export interface StandardResponseTripBoardDeleteResponse {
 
 export interface TripBoardDeleteResponse {
   tripBoardId?: number;
+}
+
+export interface ComparisonTableDeleteResponse {
+  tableId?: number;
+  message?: string;
+}
+
+/**
+ * 응답 유형
+ */
+export type StandardResponseComparisonTableDeleteResponseResponseType =
+  | "SUCCESS"
+  | "ERROR";
+/**
+ * API 응답의 표준 형식을 정의하는 클래스
+ */
+export interface StandardResponseComparisonTableDeleteResponse {
+  /** 응답 유형 */
+  responseType?: StandardResponseComparisonTableDeleteResponseResponseType;
+  /** 응답 결과 데이터 */
+  result?: ComparisonTableDeleteResponse;
 }
 
 export interface AccommodationDeleteResponse {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -33,6 +33,7 @@ import type {
   GetAccommodationCountByTripBoardIdParams,
   GetKakaoAuthorizeUrlParams,
   GetTripBoardsParams,
+  RefreshTokenRequest,
   StandardResponseAccommodationCountResponse,
   StandardResponseAccommodationDeleteResponse,
   StandardResponseAccommodationPageResponse,
@@ -42,12 +43,14 @@ import type {
   StandardResponseAuthorizeUrlResponse,
   StandardResponseBoolean,
   StandardResponseComparisonFactorList,
+  StandardResponseComparisonTableDeleteResponse,
   StandardResponseComparisonTableResponse,
   StandardResponseCreateComparisonTableResponse,
   StandardResponseInvitationCodeResponse,
   StandardResponseInvitationToggleResponse,
   StandardResponseLogoutResponse,
   StandardResponseOauthLoginResponse,
+  StandardResponseTokenSuccessResponse,
   StandardResponseTripBoardCreateResponse,
   StandardResponseTripBoardDeleteResponse,
   StandardResponseTripBoardJoinResponse,
@@ -55,6 +58,7 @@ import type {
   StandardResponseTripBoardPageResponse,
   StandardResponseTripBoardSummaryResponse,
   StandardResponseTripBoardUpdateResponse,
+  StandardResponseUserInfoResponse,
   StandardResponseWithdrawResponse,
   TripBoardCreateRequest,
   TripBoardJoinRequest,
@@ -1054,6 +1058,148 @@ export const useUpdateComparisonTable = <TError = unknown, TContext = unknown>(
 };
 
 /**
+ * 사용자가 생성한 비교표를 삭제합니다. 생성자만 삭제할 수 있습니다. (Authorization 헤더에 Bearer 토큰 필요)
+ * @summary 비교표 삭제
+ */
+export type deleteComparisonTableResponse200 = {
+  data: StandardResponseComparisonTableDeleteResponse;
+  status: 200;
+};
+
+export type deleteComparisonTableResponse401 = {
+  data: StandardResponseComparisonTableDeleteResponse;
+  status: 401;
+};
+
+export type deleteComparisonTableResponse403 = {
+  data: StandardResponseComparisonTableDeleteResponse;
+  status: 403;
+};
+
+export type deleteComparisonTableResponse404 = {
+  data: StandardResponseComparisonTableDeleteResponse;
+  status: 404;
+};
+
+export type deleteComparisonTableResponse500 = {
+  data: StandardResponseComparisonTableDeleteResponse;
+  status: 500;
+};
+
+export type deleteComparisonTableResponseComposite =
+  | deleteComparisonTableResponse200
+  | deleteComparisonTableResponse401
+  | deleteComparisonTableResponse403
+  | deleteComparisonTableResponse404
+  | deleteComparisonTableResponse500;
+
+export type deleteComparisonTableResponse =
+  deleteComparisonTableResponseComposite & {
+    headers: Headers;
+  };
+
+export const getDeleteComparisonTableUrl = (tableId: number) => {
+  return `https://api.ssok.info/api/comparison/${tableId}`;
+};
+
+export const deleteComparisonTable = async (
+  tableId: number,
+  options?: RequestInit,
+): Promise<deleteComparisonTableResponse> => {
+  return http<deleteComparisonTableResponse>(
+    getDeleteComparisonTableUrl(tableId),
+    {
+      ...options,
+      method: "DELETE",
+    },
+  );
+};
+
+export const getDeleteComparisonTableMutationOptions = <
+  TError =
+    | StandardResponseComparisonTableDeleteResponse
+    | StandardResponseComparisonTableDeleteResponse
+    | StandardResponseComparisonTableDeleteResponse
+    | StandardResponseComparisonTableDeleteResponse,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof deleteComparisonTable>>,
+    TError,
+    { tableId: number },
+    TContext
+  >;
+  request?: SecondParameter<typeof http>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof deleteComparisonTable>>,
+  TError,
+  { tableId: number },
+  TContext
+> => {
+  const mutationKey = ["deleteComparisonTable"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      "mutationKey" in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof deleteComparisonTable>>,
+    { tableId: number }
+  > = (props) => {
+    const { tableId } = props ?? {};
+
+    return deleteComparisonTable(tableId, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type DeleteComparisonTableMutationResult = NonNullable<
+  Awaited<ReturnType<typeof deleteComparisonTable>>
+>;
+
+export type DeleteComparisonTableMutationError =
+  | StandardResponseComparisonTableDeleteResponse
+  | StandardResponseComparisonTableDeleteResponse
+  | StandardResponseComparisonTableDeleteResponse
+  | StandardResponseComparisonTableDeleteResponse;
+
+/**
+ * @summary 비교표 삭제
+ */
+export const useDeleteComparisonTable = <
+  TError =
+    | StandardResponseComparisonTableDeleteResponse
+    | StandardResponseComparisonTableDeleteResponse
+    | StandardResponseComparisonTableDeleteResponse
+    | StandardResponseComparisonTableDeleteResponse,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof deleteComparisonTable>>,
+      TError,
+      { tableId: number },
+      TContext
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof deleteComparisonTable>>,
+  TError,
+  { tableId: number },
+  TContext
+> => {
+  const mutationOptions = getDeleteComparisonTableMutationOptions(options);
+
+  return useMutation(mutationOptions, queryClient);
+};
+
+/**
  * 비교표에 새로운 숙소를 추가합니다. (Authorization 헤더에 Bearer 토큰 필요)
  * @summary 비교표 숙소 추가
  */
@@ -1555,6 +1701,116 @@ export const useWithdrawUser = <TError = unknown, TContext = unknown>(
   TContext
 > => {
   const mutationOptions = getWithdrawUserMutationOptions(options);
+
+  return useMutation(mutationOptions, queryClient);
+};
+
+/**
+ * 유효한 리프레시 토큰을 사용하여 새로운 액세스 토큰과 리프레시 토큰을 발급받습니다. 기존 리프레시 토큰은 무효화되고 새로운 토큰 쌍이 생성됩니다. 토큰 회전(Token Rotation)을 통해 보안을 강화합니다. 이 API는 액세스 토큰이 만료된 상황에서 사용되므로 JWT 인증이 필요하지 않습니다.
+ * @summary 리프레시 토큰 재발급
+ */
+export type refreshTokensResponse200 = {
+  data: StandardResponseTokenSuccessResponse;
+  status: 200;
+};
+
+export type refreshTokensResponse401 = {
+  data: StandardResponseTokenSuccessResponse;
+  status: 401;
+};
+
+export type refreshTokensResponseComposite =
+  | refreshTokensResponse200
+  | refreshTokensResponse401;
+
+export type refreshTokensResponse = refreshTokensResponseComposite & {
+  headers: Headers;
+};
+
+export const getRefreshTokensUrl = () => {
+  return `https://api.ssok.info/api/oauth/refresh`;
+};
+
+export const refreshTokens = async (
+  refreshTokenRequest: RefreshTokenRequest,
+  options?: RequestInit,
+): Promise<refreshTokensResponse> => {
+  return http<refreshTokensResponse>(getRefreshTokensUrl(), {
+    ...options,
+    method: "POST",
+    headers: { "Content-Type": "application/json", ...options?.headers },
+    body: JSON.stringify(refreshTokenRequest),
+  });
+};
+
+export const getRefreshTokensMutationOptions = <
+  TError = StandardResponseTokenSuccessResponse,
+  TContext = unknown,
+>(options?: {
+  mutation?: UseMutationOptions<
+    Awaited<ReturnType<typeof refreshTokens>>,
+    TError,
+    { data: RefreshTokenRequest },
+    TContext
+  >;
+  request?: SecondParameter<typeof http>;
+}): UseMutationOptions<
+  Awaited<ReturnType<typeof refreshTokens>>,
+  TError,
+  { data: RefreshTokenRequest },
+  TContext
+> => {
+  const mutationKey = ["refreshTokens"];
+  const { mutation: mutationOptions, request: requestOptions } = options
+    ? options.mutation &&
+      "mutationKey" in options.mutation &&
+      options.mutation.mutationKey
+      ? options
+      : { ...options, mutation: { ...options.mutation, mutationKey } }
+    : { mutation: { mutationKey }, request: undefined };
+
+  const mutationFn: MutationFunction<
+    Awaited<ReturnType<typeof refreshTokens>>,
+    { data: RefreshTokenRequest }
+  > = (props) => {
+    const { data } = props ?? {};
+
+    return refreshTokens(data, requestOptions);
+  };
+
+  return { mutationFn, ...mutationOptions };
+};
+
+export type RefreshTokensMutationResult = NonNullable<
+  Awaited<ReturnType<typeof refreshTokens>>
+>;
+export type RefreshTokensMutationBody = RefreshTokenRequest;
+export type RefreshTokensMutationError = StandardResponseTokenSuccessResponse;
+
+/**
+ * @summary 리프레시 토큰 재발급
+ */
+export const useRefreshTokens = <
+  TError = StandardResponseTokenSuccessResponse,
+  TContext = unknown,
+>(
+  options?: {
+    mutation?: UseMutationOptions<
+      Awaited<ReturnType<typeof refreshTokens>>,
+      TError,
+      { data: RefreshTokenRequest },
+      TContext
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseMutationResult<
+  Awaited<ReturnType<typeof refreshTokens>>,
+  TError,
+  { data: RefreshTokenRequest },
+  TContext
+> => {
+  const mutationOptions = getRefreshTokensMutationOptions(options);
 
   return useMutation(mutationOptions, queryClient);
 };
@@ -2077,6 +2333,311 @@ export const useToggleInvitationActive = <TError = unknown, TContext = unknown>(
 
   return useMutation(mutationOptions, queryClient);
 };
+
+/**
+ * 현재 로그인한 사용자의 기본 정보(닉네임, 프로필 이미지)를 조회합니다.
+ * @summary 사용자 정보 조회
+ */
+export type getUserInfoResponse200 = {
+  data: StandardResponseUserInfoResponse;
+  status: 200;
+};
+
+export type getUserInfoResponse401 = {
+  data: StandardResponseUserInfoResponse;
+  status: 401;
+};
+
+export type getUserInfoResponse404 = {
+  data: StandardResponseUserInfoResponse;
+  status: 404;
+};
+
+export type getUserInfoResponseComposite =
+  | getUserInfoResponse200
+  | getUserInfoResponse401
+  | getUserInfoResponse404;
+
+export type getUserInfoResponse = getUserInfoResponseComposite & {
+  headers: Headers;
+};
+
+export const getGetUserInfoUrl = () => {
+  return `https://api.ssok.info/api/users/me`;
+};
+
+export const getUserInfo = async (
+  options?: RequestInit,
+): Promise<getUserInfoResponse> => {
+  return http<getUserInfoResponse>(getGetUserInfoUrl(), {
+    ...options,
+    method: "GET",
+  });
+};
+
+export const getGetUserInfoQueryKey = () => {
+  return [`https://api.ssok.info/api/users/me`] as const;
+};
+
+export const getGetUserInfoQueryOptions = <
+  TData = Awaited<ReturnType<typeof getUserInfo>>,
+  TError = StandardResponseUserInfoResponse | StandardResponseUserInfoResponse,
+>(options?: {
+  query?: Partial<
+    UseQueryOptions<Awaited<ReturnType<typeof getUserInfo>>, TError, TData>
+  >;
+  request?: SecondParameter<typeof http>;
+}) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getGetUserInfoQueryKey();
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getUserInfo>>> = ({
+    signal,
+  }) => getUserInfo({ signal, ...requestOptions });
+
+  return { queryKey, queryFn, ...queryOptions } as UseQueryOptions<
+    Awaited<ReturnType<typeof getUserInfo>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData> };
+};
+
+export type GetUserInfoQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getUserInfo>>
+>;
+export type GetUserInfoQueryError =
+  | StandardResponseUserInfoResponse
+  | StandardResponseUserInfoResponse;
+
+export function useGetUserInfo<
+  TData = Awaited<ReturnType<typeof getUserInfo>>,
+  TError = StandardResponseUserInfoResponse | StandardResponseUserInfoResponse,
+>(
+  options: {
+    query: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getUserInfo>>, TError, TData>
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getUserInfo>>,
+          TError,
+          Awaited<ReturnType<typeof getUserInfo>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData>;
+};
+export function useGetUserInfo<
+  TData = Awaited<ReturnType<typeof getUserInfo>>,
+  TError = StandardResponseUserInfoResponse | StandardResponseUserInfoResponse,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getUserInfo>>, TError, TData>
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getUserInfo>>,
+          TError,
+          Awaited<ReturnType<typeof getUserInfo>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> };
+export function useGetUserInfo<
+  TData = Awaited<ReturnType<typeof getUserInfo>>,
+  TError = StandardResponseUserInfoResponse | StandardResponseUserInfoResponse,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getUserInfo>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> };
+/**
+ * @summary 사용자 정보 조회
+ */
+
+export function useGetUserInfo<
+  TData = Awaited<ReturnType<typeof getUserInfo>>,
+  TError = StandardResponseUserInfoResponse | StandardResponseUserInfoResponse,
+>(
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getUserInfo>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & { queryKey: DataTag<QueryKey, TData> } {
+  const queryOptions = getGetUserInfoQueryOptions(options);
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData> };
+
+  query.queryKey = queryOptions.queryKey;
+
+  return query;
+}
+
+/**
+ * @summary 사용자 정보 조회
+ */
+export const prefetchGetUserInfoQuery = async <
+  TData = Awaited<ReturnType<typeof getUserInfo>>,
+  TError = StandardResponseUserInfoResponse | StandardResponseUserInfoResponse,
+>(
+  queryClient: QueryClient,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<Awaited<ReturnType<typeof getUserInfo>>, TError, TData>
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+): Promise<QueryClient> => {
+  const queryOptions = getGetUserInfoQueryOptions(options);
+
+  await queryClient.prefetchQuery(queryOptions);
+
+  return queryClient;
+};
+
+export const getGetUserInfoSuspenseQueryOptions = <
+  TData = Awaited<ReturnType<typeof getUserInfo>>,
+  TError = StandardResponseUserInfoResponse | StandardResponseUserInfoResponse,
+>(options?: {
+  query?: Partial<
+    UseSuspenseQueryOptions<
+      Awaited<ReturnType<typeof getUserInfo>>,
+      TError,
+      TData
+    >
+  >;
+  request?: SecondParameter<typeof http>;
+}) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey = queryOptions?.queryKey ?? getGetUserInfoQueryKey();
+
+  const queryFn: QueryFunction<Awaited<ReturnType<typeof getUserInfo>>> = ({
+    signal,
+  }) => getUserInfo({ signal, ...requestOptions });
+
+  return { queryKey, queryFn, ...queryOptions } as UseSuspenseQueryOptions<
+    Awaited<ReturnType<typeof getUserInfo>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData> };
+};
+
+export type GetUserInfoSuspenseQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getUserInfo>>
+>;
+export type GetUserInfoSuspenseQueryError =
+  | StandardResponseUserInfoResponse
+  | StandardResponseUserInfoResponse;
+
+export function useGetUserInfoSuspense<
+  TData = Awaited<ReturnType<typeof getUserInfo>>,
+  TError = StandardResponseUserInfoResponse | StandardResponseUserInfoResponse,
+>(
+  options: {
+    query: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getUserInfo>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseSuspenseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData>;
+};
+export function useGetUserInfoSuspense<
+  TData = Awaited<ReturnType<typeof getUserInfo>>,
+  TError = StandardResponseUserInfoResponse | StandardResponseUserInfoResponse,
+>(
+  options?: {
+    query?: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getUserInfo>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseSuspenseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData>;
+};
+export function useGetUserInfoSuspense<
+  TData = Awaited<ReturnType<typeof getUserInfo>>,
+  TError = StandardResponseUserInfoResponse | StandardResponseUserInfoResponse,
+>(
+  options?: {
+    query?: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getUserInfo>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseSuspenseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData>;
+};
+/**
+ * @summary 사용자 정보 조회
+ */
+
+export function useGetUserInfoSuspense<
+  TData = Awaited<ReturnType<typeof getUserInfo>>,
+  TError = StandardResponseUserInfoResponse | StandardResponseUserInfoResponse,
+>(
+  options?: {
+    query?: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getUserInfo>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseSuspenseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData>;
+} {
+  const queryOptions = getGetUserInfoSuspenseQueryOptions(options);
+
+  const query = useSuspenseQuery(
+    queryOptions,
+    queryClient,
+  ) as UseSuspenseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData>;
+  };
+
+  query.queryKey = queryOptions.queryKey;
+
+  return query;
+}
 
 /**
  * 여행 보드에서 현재 사용자의 초대 링크 정보를 조회합니다. 초대 코드, 활성화 상태 등의 정보를 포함합니다.


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 새로 추가된 API를 반영했습니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
commit-id:68d8d7bc

---

**Stack**:
- #130
- #129 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 내 정보 조회(닉네임, 프로필 이미지) 엔드포인트 추가 및 클라이언트/React Query 훅 제공
  - 토큰 재발급 엔드포인트 추가 및 클라이언트/React Query 훅 제공
  - 사용자 비교표 삭제 엔드포인트 추가 및 클라이언트/React Query 훅 제공
  - OpenAPI 문서에 USER 태그 및 신규 경로/스키마 반영, 표준화된 응답 래퍼 도입

- Tests
  - MSW 목 응답/핸들러 추가: 내 정보 조회, 토큰 재발급, 비교표 삭제
  - 통합 목 세트에 신규 핸들러 연동

<!-- end of auto-generated comment: release notes by coderabbit.ai -->