### PR TITLE
[Y26W2-314] feat(ui): TextField maxLegnth 대응하여 개발

### DIFF
--- a/packages/ui/src/components/text-field/index.stories.tsx
+++ b/packages/ui/src/components/text-field/index.stories.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryFn } from "@storybook/react-vite";
+import { useState } from "react";
 import IcAlert from "@/assets/icons/ic_alert.svg?react";
 import IcLink from "@/assets/icons/ic_link.svg?react";
 import { TextField, type TextFieldProps } from "@/components/text-field";
@@ -26,6 +27,9 @@ const meta: Meta<TextFieldProps> = {
     value: {
       control: "text",
     },
+    maxLength: {
+      control: "number",
+    },
   },
   decorators: [
     (Story) => (
@@ -36,7 +40,17 @@ const meta: Meta<TextFieldProps> = {
   ],
 };
 
-const Template: StoryFn<TextFieldProps> = (args) => <TextField {...args} />;
+const Template: StoryFn<TextFieldProps> = (args) => {
+  const [value, setValue] = useState(args.value || "");
+
+  return (
+    <TextField
+      {...args}
+      value={value}
+      onChange={(e) => setValue(e.target.value)}
+    />
+  );
+};
 
 export const Default: StoryFn<TextFieldProps> = Template.bind({});
 Default.args = {
@@ -49,6 +63,30 @@ WithError.args = {
   value: "airbnb.com/",
   endIcon: <IcAlert width={24} height={24} />,
   hasError: true,
+};
+
+export const WithMaxLength: StoryFn<TextFieldProps> = Template.bind({});
+WithMaxLength.args = {
+  placeholder: "국가 혹은 도시를 입력해주세요.",
+  maxLength: 20,
+  value: "서울",
+};
+
+export const WithMaxLengthAndIcon: StoryFn<TextFieldProps> = Template.bind({});
+WithMaxLengthAndIcon.args = {
+  placeholder: "호텔명을 입력해주세요.",
+  maxLength: 30,
+  value: "그랜드 하얏트 서울",
+  icon: <IcLink width={24} height={24} />,
+};
+
+export const WithMaxLengthAndEndIcon: StoryFn<TextFieldProps> = Template.bind(
+  {},
+);
+WithMaxLengthAndEndIcon.args = {
+  placeholder: "링크를 입력해주세요.",
+  maxLength: 20,
+  value: "https://example.com/foo/foo/foo/foo/foo/foo/foo/foo",
 };
 
 export default meta;

--- a/packages/ui/src/components/text-field/index.tsx
+++ b/packages/ui/src/components/text-field/index.tsx
@@ -1,5 +1,6 @@
 import { cva, type VariantProps } from "class-variance-authority";
 import type { ComponentProps, ReactNode } from "react";
+import IcAlert from "@/assets/icons/ic_alert.svg?react";
 import { cn } from "@/utils";
 
 export interface TextFieldProps
@@ -8,6 +9,7 @@ export interface TextFieldProps
   icon?: ReactNode;
   endIcon?: ReactNode;
   hasError?: boolean;
+  maxLength?: number;
 }
 
 const variants = cva(
@@ -38,12 +40,17 @@ const variants = cva(
 export const TextField = ({
   className,
   icon,
-  endIcon,
-  hasError = false,
   value,
+  maxLength,
   ...props
 }: TextFieldProps) => {
   const hasValue = String(value).length > 0;
+  const currentLength = String(value).length;
+  const isOverLimit = maxLength && currentLength > maxLength;
+
+  const hasError = props.hasError || isOverLimit || false;
+  const endIcon = props.endIcon || (isOverLimit ? <IcAlert /> : undefined);
+  const showCharacterCount = maxLength && !props.disabled;
 
   return (
     <div className={cn(variants({ hasError }), className)}>
@@ -61,16 +68,40 @@ export const TextField = ({
       )}
       <input
         value={value}
+        maxLength={maxLength}
         className={cn(
           "w-full px-[1.6rem] py-[1.2rem]",
           "border-none bg-transparent outline-none",
           "text-inherit placeholder:text-neutral-70",
           "transition-all duration-200",
           icon && !hasValue && "indent-[3.2rem]",
-          endIcon && "pr-[4.8rem]",
+          endIcon && !showCharacterCount && "pr-[4.8rem]",
+          endIcon && showCharacterCount && "pr-[11.2rem]",
+          !endIcon && showCharacterCount && "pr-[6.4rem]",
         )}
         {...props}
       />
+      {showCharacterCount && (
+        <div
+          className={cn(
+            "-translate-y-1/2 absolute top-1/2 flex items-center gap-[0.2rem]",
+            "pointer-events-none text-caption1-medi12",
+            endIcon ? "right-[4.8rem]" : "right-[1.6rem]",
+            hasError ? "text-error-80" : "text-neutral-70",
+          )}
+        >
+          <span
+            className={cn(
+              "text-caption1-semi12",
+              hasError ? "text-error-70" : "text-neutral-60",
+            )}
+          >
+            {currentLength}
+          </span>
+          <span>/</span>
+          <span>{maxLength}</span>
+        </div>
+      )}
       {endIcon && (
         <div
           data-slot="icon"


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- TextField 컴포넌트가 `maxLength`를 보여줄 수 있도록 구현했습니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

<img width="633" height="638" alt="CleanShot 2025-08-15 at 17 55 58" src="https://github.com/user-attachments/assets/9cde963e-c64f-4367-aab7-e034b62b185f" />


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
commit-id:11b151be

---

**Stack**:
- #139
- #136
- #133 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->
