### PR TITLE
[Y26W2-266] fix(ui): 지도 Pin 최대너비 대응 

### DIFF
--- a/packages/ui/src/components/pin/index.tsx
+++ b/packages/ui/src/components/pin/index.tsx
@@ -9,6 +9,7 @@ export type PinProps = {
 export const Pin = ({ children, className, isActive, ...props }: PinProps) => {
   return (
     <button
+      type="button"
       className={cn(
         // 본체 스타일
         "relative inline-flex items-center justify-center text-heading2-semi18 text-primary-5 shadow-[2px_4px_6px_0px_rgba(0,0,0,0.2)]",

--- a/packages/ui/src/components/pin/index.tsx
+++ b/packages/ui/src/components/pin/index.tsx
@@ -11,7 +11,7 @@ export const Pin = ({ children, className, isActive, ...props }: PinProps) => {
     <button
       className={cn(
         // 본체 스타일
-        "relative inline-flex w-max items-center justify-center text-heading2-semi18 text-primary-5 shadow-[2px_4px_6px_0px_rgba(0,0,0,0.2)]",
+        "relative inline-flex items-center justify-center text-heading2-semi18 text-primary-5 shadow-[2px_4px_6px_0px_rgba(0,0,0,0.2)]",
         "rounded-[4.8rem] border border-neutral-70 bg-neutral-100 px-[1.6rem] py-[0.8rem]",
         "hover:border-neutral-60 focus:border-primary-5",
         "focus:bg-primary-5 focus:text-primary-100",
@@ -38,7 +38,9 @@ export const Pin = ({ children, className, isActive, ...props }: PinProps) => {
       )}
       {...props}
     >
-      {children}
+      <span className="block max-w-[25rem] overflow-hidden text-ellipsis whitespace-nowrap">
+        {children}
+      </span>
     </button>
   );
 };

--- a/packages/ui/src/components/pin/index.tsx
+++ b/packages/ui/src/components/pin/index.tsx
@@ -38,7 +38,7 @@ export const Pin = ({ children, className, isActive, ...props }: PinProps) => {
       )}
       {...props}
     >
-      <span className="block max-w-[25rem] overflow-hidden text-ellipsis whitespace-nowrap">
+      <span className="block max-w-[21.6rem] overflow-hidden text-ellipsis whitespace-nowrap">
         {children}
       </span>
     </button>

--- a/packages/ui/src/components/pin/pin.stories.tsx
+++ b/packages/ui/src/components/pin/pin.stories.tsx
@@ -17,33 +17,48 @@ export const AllKinds = () => {
     <div className="flex flex-col items-center gap-6 bg-gray-50 p-8">
       <div>
         <h3 className="mb-2 font-semibold text-lg">Hilton Tokyo 1</h3>
-        <Pin>Hilton Tokyo 1</Pin>
+        <Pin isActive={false}>Hilton Tokyo 1</Pin>
       </div>
 
       <div>
         <h3 className="mb-2 font-semibold text-lg">Hilton Tokyo 2 (hover)</h3>
-        <Pin className="border-neutral-60 before:border-t-neutral-60 after:border-t-neutral-100">
+        <Pin
+          isActive={false}
+          className="border-neutral-60 before:border-t-neutral-60 after:border-t-neutral-100"
+        >
           Hilton Tokyo 2
         </Pin>
       </div>
 
       <div>
         <h3 className="mb-2 font-semibold text-lg">Hilton Tokyo 3 (focus)</h3>
-        <Pin className="border-primary-5 bg-primary-5 text-primary-100 before:border-t-primary-5 after:border-t-primary-5 hover:after:border-t-primary-5">
+        <Pin
+          isActive
+          className="border-primary-5 bg-primary-5 text-primary-100 before:border-t-primary-5 after:border-t-primary-5 hover:after:border-t-primary-5"
+        >
           Hilton Tokyo 3
+        </Pin>
+      </div>
+
+      <div>
+        <h3 className="mb-2 text-center font-semibold text-lg">
+          긴 호텔명 예시{" "}
+        </h3>
+        <Pin isActive={false}>
+          호텔 히가시 신주쿠 도쿄 (E-Hotel Higashi Shinjuku Tokyo)
         </Pin>
       </div>
 
       <div>
         <h3 className="mb-2 font-semibold text-lg">Example Texts</h3>
         <div className="flex gap-4">
-          <Pin>Ssok 지수</Pin>
-          <Pin>Ssok 경민</Pin>
-          <Pin>Ssok 시언</Pin>
-          <Pin>Ssok 수빈</Pin>
-          <Pin>Ssok 고은</Pin>
-          <Pin>Ssok 세환</Pin>
-          <Pin>Ssok 성연</Pin>
+          <Pin isActive={false}>Ssok 지수</Pin>
+          <Pin isActive={false}>Ssok 경민</Pin>
+          <Pin isActive={false}>Ssok 시언</Pin>
+          <Pin isActive={false}>Ssok 수빈</Pin>
+          <Pin isActive={false}>Ssok 고은</Pin>
+          <Pin isActive={false}>Ssok 세환</Pin>
+          <Pin isActive={false}>Ssok 성연</Pin>
         </div>
       </div>
     </div>


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 숙소명이 길어질 것을 대비하여, `max-width`를 250px로 제한했습니다

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

| ![image](https://github.com/user-attachments/assets/e645b545-51f6-46b7-b82f-d9cfca97f877 ) | ![image](https://github.com/user-attachments/assets/a2d33185-bea2-4266-a536-27a62f373b66) |
| --- | --- |


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Style**
  - Pin 버튼의 너비가 더 이상 강제되지 않고 자동으로 결정되도록 레이아웃을 조정했으며, 정렬은 중앙으로 유지했습니다.
  - 버튼 내부 텍스트는 한 줄로 고정되어 길 경우 말줄임표(…)로 표시되도록 개선해 레이아웃 넘침을 방지했습니다.
  - 동작과 공개 API(컴포넌트 시그니처)는 변경되지 않았습니다.

- **Documentation**
  - 스토리 예제에 모든 항목의 isActive 상태를 명시하고, 긴 호텔명 예시를 추가해 표시 형태를 확인할 수 있도록 갱신했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->