### PR TITLE
[Y26W2-312] feat(ui): DateRangePicker 구현

### DIFF
--- a/packages/ui/src/components/date-button/index.tsx
+++ b/packages/ui/src/components/date-button/index.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import type { ComponentProps } from "react";
+import { forwardRef } from "react";
 import IcCalendar from "@/assets/icons/ic_calendar.svg?react";
 import IcCaretDown from "@/assets/icons/ic_caret_down.svg?react";
 import { cn } from "@/utils";
@@ -12,35 +13,43 @@ export interface DateButtonProps
   placeholder?: string;
 }
 
-export const DateButton = ({
-  value,
-  placeholder = "날짜 선택",
-  disabled,
-  onClick,
-  className,
-  ...props
-}: DateButtonProps) => {
-  return (
-    <button
-      type="button"
-      onClick={onClick}
-      disabled={disabled}
-      className={cn(
-        "flex h-[5.2rem] cursor-pointer items-center gap-[0.8rem] rounded-[0.8rem] border px-[1.2rem] py-[1.4rem] text-body1-semi16 transition-colors",
-        "border-neutral-90 bg-white",
-        "hover:border-neutral-80 hover:bg-neutral-98",
-        "focus:border-neutral-80 focus:bg-neutral-95 focus:outline-none",
-        "disabled:cursor-not-allowed disabled:opacity-50",
-        className,
-      )}
-      {...props}
-    >
-      <IcCalendar width={24} height={24} className="text-neutral-50" />
-      {value && <span className="text-neutral-30">{formatDate(value)}</span>}
-      {!value && <span className="text-neutral-50">{placeholder}</span>}
-      <IcCaretDown width={16} height={16} className="text-neutral-50" />
-    </button>
-  );
-};
+export const DateButton = forwardRef<HTMLButtonElement, DateButtonProps>(
+  (
+    {
+      value,
+      placeholder = "날짜 선택",
+      disabled,
+      onClick,
+      className,
+      ...props
+    },
+    ref,
+  ) => {
+    return (
+      <button
+        ref={ref}
+        type="button"
+        onClick={onClick}
+        disabled={disabled}
+        className={cn(
+          "flex h-[5.2rem] cursor-pointer items-center gap-[0.8rem] rounded-[0.8rem] border px-[1.2rem] py-[1.4rem] text-body1-semi16 transition-colors",
+          "border-neutral-90 bg-white",
+          "hover:border-neutral-80 hover:bg-neutral-98",
+          "focus:border-neutral-80 focus:bg-neutral-95 focus:outline-none",
+          "disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        {...props}
+      >
+        <IcCalendar width={24} height={24} className="text-neutral-50" />
+        {value && <span className="text-neutral-30">{formatDate(value)}</span>}
+        {!value && <span className="text-neutral-50">{placeholder}</span>}
+        <IcCaretDown width={16} height={16} className="text-neutral-50" />
+      </button>
+    );
+  },
+);
+
+DateButton.displayName = "DateButton";
 
 export default DateButton;

--- a/packages/ui/src/components/date-range-picker/index.stories.tsx
+++ b/packages/ui/src/components/date-range-picker/index.stories.tsx
@@ -1,0 +1,95 @@
+import type { Meta, StoryFn } from "@storybook/react-vite";
+import { useState } from "react";
+import {
+  DateRangePicker,
+  type DateRangePickerProps,
+  type DateRangeValue,
+} from "./";
+
+const meta: Meta<DateRangePickerProps> = {
+  title: "Components/DateRangePicker",
+  component: DateRangePicker,
+  parameters: {
+    layout: "padded",
+  },
+  tags: ["autodocs"],
+  decorators: [
+    (Story) => (
+      <div className="mx-auto w-full max-w-[60rem]">
+        <Story />
+      </div>
+    ),
+  ],
+};
+
+// 기본 사용법
+export const Default: StoryFn = () => {
+  const [value, setValue] = useState<DateRangeValue>({});
+
+  return (
+    <div className="space-y-4">
+      <DateRangePicker
+        value={value}
+        onChange={setValue}
+        placeholder={{ from: "출발일 선택", to: "도착일 선택" }}
+        render={({ from, to }) => (
+          <div className="flex gap-4">
+            <div>{from}</div>
+            <div>{to}</div>
+          </div>
+        )}
+      />
+
+      <div className="rounded-lg bg-neutral-95 p-4 text-caption1-medi12 text-neutral-50">
+        선택된 범위: {value.from?.toLocaleDateString("ko-KR")} ~{" "}
+        {value.to?.toLocaleDateString("ko-KR")}
+      </div>
+    </div>
+  );
+};
+
+// 초기값이 있는 경우
+export const WithInitialValue: StoryFn = () => {
+  const [value, setValue] = useState<DateRangeValue>({
+    from: new Date("2025-06-01"),
+    to: new Date("2025-06-05"),
+  });
+
+  return (
+    <DateRangePicker
+      value={value}
+      onChange={setValue}
+      render={({ from, to }) => (
+        <div className="flex gap-4">
+          {from}
+          {to}
+        </div>
+      )}
+    />
+  );
+};
+
+// 비활성화 상태
+export const Disabled: StoryFn = () => {
+  const [value, setValue] = useState<DateRangeValue>({
+    from: new Date("2025-06-01"),
+    to: new Date("2025-06-05"),
+  });
+
+  return (
+    <DateRangePicker
+      value={value}
+      onChange={setValue}
+      disabled={true}
+      placeholder={{ from: "출발일", to: "도착일" }}
+      render={({ from, to }) => (
+        <div className="flex gap-4">
+          {from}
+          {to}
+        </div>
+      )}
+    />
+  );
+};
+
+export default meta;

--- a/packages/ui/src/components/date-range-picker/index.tsx
+++ b/packages/ui/src/components/date-range-picker/index.tsx
@@ -1,0 +1,151 @@
+"use client";
+
+import { useRef, useState } from "react";
+import type { DateRange } from "react-day-picker";
+import { useOutsideClickEffect } from "react-simplikit";
+import Calendar from "@/components/calendar";
+import { DateButton } from "@/components/date-button";
+import { useFloating } from "@/hooks/use-floating";
+import { cn } from "@/utils";
+
+export type DateRangeValue = {
+  from?: Date;
+  to?: Date;
+};
+
+export type DateRangePickerRenderProps = {
+  from: React.ReactNode;
+  to: React.ReactNode;
+};
+
+export type DateRangePickerProps = {
+  value: DateRangeValue;
+  onChange: (range: DateRangeValue) => void;
+  render: (props: DateRangePickerRenderProps) => React.ReactNode;
+  disabled?: boolean;
+  placeholder?: { from: string; to: string };
+  className?: string;
+};
+
+export const DateRangePicker = ({
+  value,
+  onChange,
+  render,
+  disabled = false,
+  placeholder = { from: "출발일 선택", to: "도착일 선택" },
+  className,
+}: DateRangePickerProps) => {
+  const [open, setOpen] = useState(false);
+  const [activeField, setRawActiveField] = useState<"from" | "to" | null>(null);
+
+  const refs = {
+    from: useRef<HTMLButtonElement>(null),
+    to: useRef<HTMLButtonElement>(null),
+  };
+
+  const { referenceRef, floatingRef, floatingStyles, refresh } = useFloating<
+    HTMLButtonElement,
+    HTMLDivElement
+  >({ offset: 8, enabled: open });
+
+  const setActiveField = (field: "from" | "to" | null) => {
+    setRawActiveField(field);
+
+    // reference 업데이트
+    if (field === "from" && refs.from.current) {
+      referenceRef.current = refs.from.current;
+    } else if (field === "to" && refs.to.current) {
+      referenceRef.current = refs.to.current;
+    }
+
+    refresh();
+    referenceRef.current?.focus();
+  };
+
+  useOutsideClickEffect(
+    [refs.from.current, refs.to.current, floatingRef.current],
+    () => {
+      setOpen(false);
+      setActiveField(null);
+    },
+  );
+
+  const openCalendar = (field: "from" | "to") => {
+    if (disabled) {
+      return;
+    }
+    setActiveField(field);
+    setOpen(true);
+  };
+
+  const closeCalendar = () => {
+    setOpen(false);
+    setActiveField(null);
+  };
+
+  const setFrom = (date: Date | undefined) => {
+    onChange({ ...value, from: date });
+  };
+
+  const setTo = (date: Date | undefined) => {
+    onChange({ ...value, to: date });
+  };
+
+  const handleDateSelect = (selected: DateRange | undefined) => {
+    if (!selected) {
+      return;
+    }
+
+    if (activeField === "from") {
+      if (selected.from) {
+        setFrom(selected.from);
+        // from 선택 후 to로 자동 전환
+        if (!value.to || selected.from > value.to) {
+          setActiveField("to");
+        }
+      }
+    } else if (activeField === "to") {
+      if (selected.to || selected.from) {
+        setTo(selected.to || selected.from);
+      }
+    }
+  };
+
+  return (
+    <div className={cn("relative", className)}>
+      {render({
+        from: (
+          <DateButton
+            ref={refs.from}
+            value={value.from}
+            placeholder={placeholder.from}
+            onClick={() => openCalendar("from")}
+            disabled={disabled}
+          />
+        ),
+        to: (
+          <DateButton
+            ref={refs.to}
+            value={value.to}
+            placeholder={placeholder.to}
+            onClick={() => openCalendar("to")}
+            disabled={disabled}
+          />
+        ),
+      })}
+      {open && (
+        <div ref={floatingRef} style={floatingStyles} className="w-fit">
+          <Calendar
+            selectedDate={
+              value.from ? { from: value.from, to: value.to } : undefined
+            }
+            onDateSelect={handleDateSelect}
+            onApplyDate={closeCalendar}
+          />
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default DateRangePicker;

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -60,6 +60,12 @@ export { Chip } from "@/components/chip";
 export type { ConfirmProps } from "@/components/confirm";
 export { Confirm } from "@/components/confirm";
 export { DateButton, type DateButtonProps } from "@/components/date-button";
+export {
+  DateRangePicker,
+  type DateRangePickerProps,
+  type DateRangePickerRenderProps,
+  type DateRangeValue,
+} from "@/components/date-range-picker";
 export { Graph } from "@/components/graph";
 export { AddIconButton } from "@/components/icon-button/add-icon-button";
 export { CheckIconButton } from "@/components/icon-button/check-icon-button";


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- DateRagnePicker를 구현해 from, to를 선택할 수 있는 input component를 만들었습니다.
- DateRangePicker의 구현을 위해 `useFloating` hook도 조금 수정했습니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

<img width="430" height="479" alt="CleanShot 2025-08-15 at 19 14 53" src="https://github.com/user-attachments/assets/186167dc-6978-4648-9fc1-f4f2871835f8" />

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
commit-id:780cbf4b

---

**Stack**:
- #139
- #136 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->
