### PR TITLE
[Y26W2-317] feat(api): OpenAPI 최신화 반영

### DIFF
--- a/packages/api/src/api/openapi.json
+++ b/packages/api/src/api/openapi.json
@@ -1330,6 +1330,11 @@
             "description": "사용자 닉네임",
             "example": "홍길동"
           },
+          "email": {
+            "type": "string",
+            "description": "사용자 이메일",
+            "example": "abc1234@gmail.com"
+          },
           "token": {
             "$ref": "#/components/schemas/TokenSuccessResponse",
             "description": "토큰 정보"
@@ -1617,6 +1622,11 @@
             "type": "string",
             "description": "유저 프로필 이미지 URL",
             "example": "https://example.com/profile/user123.jpg"
+          },
+          "email": {
+            "type": "string",
+            "description": "사용자 이메일",
+            "example": "abc1234@gmail.com"
           }
         }
       },

--- a/packages/api/src/index.msw.ts
+++ b/packages/api/src/index.msw.ts
@@ -1183,6 +1183,10 @@ export const getExchangeKakaoTokenResponseMock = (
         faker.string.alpha({ length: { min: 10, max: 20 } }),
         undefined,
       ]),
+      email: faker.helpers.arrayElement([
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
+        undefined,
+      ]),
       token: faker.helpers.arrayElement([
         {
           accessToken: faker.helpers.arrayElement([
@@ -1293,6 +1297,10 @@ export const getGetUserInfoResponseMock = (
         undefined,
       ]),
       profileImageUrl: faker.helpers.arrayElement([
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
+        undefined,
+      ]),
+      email: faker.helpers.arrayElement([
         faker.string.alpha({ length: { min: 10, max: 20 } }),
         undefined,
       ]),

--- a/packages/api/src/index.schemas.ts
+++ b/packages/api/src/index.schemas.ts
@@ -334,6 +334,8 @@ export interface OauthLoginResponse {
   userId?: number;
   /** 사용자 닉네임 */
   nickname?: string;
+  /** 사용자 이메일 */
+  email?: string;
   /** 토큰 정보 */
   token?: TokenSuccessResponse;
 }
@@ -561,6 +563,8 @@ export interface UserInfoResponse {
   nickname?: string;
   /** 유저 프로필 이미지 URL */
   profileImageUrl?: string;
+  /** 사용자 이메일 */
+  email?: string;
 }
 
 export type ParticipantProfileResponseRole = "OWNER" | "MEMBER";


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- Open API 최산화하여 codegen 했습니다

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * OAuth 로그인 응답과 사용자 정보 응답에 이메일(email) 필드가 추가되었습니다. 이제 응답에서 사용자 이메일을 선택적으로 제공받을 수 있어, 프로필 표시나 연락용 식별 등에 활용할 수 있습니다. 기존 필드는 변경되지 않아 하위 호환성이 유지되며, 스키마 예시에는 "abc1234@gmail.com"이 포함됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->