### PR TITLE
[Y26W2-323] feat(web): 여행보드 없는 경우 여행 생성 페이지로 리다이렉트

### DIFF
--- a/apps/web/src/app/boards/page.tsx
+++ b/apps/web/src/app/boards/page.tsx
@@ -1,5 +1,13 @@
-import { prefetchGetTripBoardsInfiniteQuery } from "@ssok/api";
-import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import {
+  getGetTripBoardsInfiniteQueryOptions,
+  type getTripBoards,
+  prefetchGetTripBoardsInfiniteQuery,
+} from "@ssok/api";
+import {
+  dehydrate,
+  HydrationBoundary,
+  type InfiniteData,
+} from "@tanstack/react-query";
 import { redirect } from "next/navigation";
 import { auth } from "@/domains/auth";
 import DashboardView from "@/domains/dashboard/views/dashboard-view";
@@ -23,6 +31,15 @@ const DashboardPage = async () => {
       },
     },
   );
+
+  const data = queryClient.getQueryData<
+    InfiniteData<Awaited<ReturnType<typeof getTripBoards>>>
+  >(getGetTripBoardsInfiniteQueryOptions({ page: 0, size: 10 }).queryKey);
+  const savedList = data?.pages[0]?.data?.result?.tripBoards;
+
+  if (!savedList || savedList.length === 0) {
+    redirect("/boards/new");
+  }
 
   return (
     <HydrationBoundary state={dehydrate(queryClient)}>

--- a/apps/web/src/app/boards/page.tsx
+++ b/apps/web/src/app/boards/page.tsx
@@ -1,5 +1,5 @@
 import {
-  getGetTripBoardsInfiniteQueryOptions,
+  getGetTripBoardsQueryKey,
   type getTripBoards,
   prefetchGetTripBoardsInfiniteQuery,
 } from "@ssok/api";
@@ -34,7 +34,7 @@ const DashboardPage = async () => {
 
   const data = queryClient.getQueryData<
     InfiniteData<Awaited<ReturnType<typeof getTripBoards>>>
-  >(getGetTripBoardsInfiniteQueryOptions({ page: 0, size: 10 }).queryKey);
+  >(getGetTripBoardsQueryKey({ page: 0, size: 10 }));
   const savedList = data?.pages[0]?.data?.result?.tripBoards;
 
   if (!savedList || savedList.length === 0) {


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- prefetch 된 queryClient 에서 data를 받아와, 여행 숙소 목록이 빈 경우 -> 여행 생성 페이지로 리다이렉트됩니다 

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

https://github.com/user-attachments/assets/0df8b4bc-a48f-4067-9968-1312395a9f35


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 보드가 하나도 없는 사용자는 보드 리스트 대신 자동으로 보드 생성 페이지로 이동해 첫 설정을 빠르게 진행합니다.
  * 로그인되지 않은 사용자는 계속 로그인 페이지로 이동하며, 보드가 있는 경우 기존 대시보드가 정상 표시됩니다.
  * 초기 데이터 로딩 후 보드 유무를 판단해 빈 화면 노출을 줄이고 탐색 흐름을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->