### PR TITLE
[Y26W2-324] feat(web): 여행보드에서 action Card 를 통한 숙소 생성 

### DIFF
--- a/apps/web/src/domains/dashboard/components/board-create-form/index.tsx
+++ b/apps/web/src/domains/dashboard/components/board-create-form/index.tsx
@@ -59,7 +59,7 @@ const BoardCreateForm = ({ className }: BoardCreateFormProps) => {
       const response = await createTripBoardMutation.mutateAsync({ data });
 
       if (response.data.result?.tripBoardId) {
-        router.push(`/boards/${response.data.result.tripBoardId}`);
+        router.push(`/boards/${response.data.result.tripBoardId}/lists`);
       } else {
         console.error(response.data);
         throw new Error(`보드 생성 API 요청 실패`);

--- a/apps/web/src/domains/dashboard/views/dashboard-view.tsx
+++ b/apps/web/src/domains/dashboard/views/dashboard-view.tsx
@@ -1,13 +1,16 @@
 "use client";
 
 import { useGetTripBoardsInfinite } from "@ssok/api";
-import { ActionCard, TravelBoard } from "@ssok/ui";
-import { useEffect } from "react";
+import { ActionCard, Popup, TravelBoard } from "@ssok/ui";
+import Link from "next/link";
+import { useEffect, useState } from "react";
 import Header from "@/shared/components/header";
 import useSession from "@/shared/hooks/use-session";
+import BoardCreateForm from "../components/board-create-form";
 
 const DashboardView = () => {
   const { accessToken } = useSession({ required: true });
+  const [isCreateFormOpen, setIsCreateFormOpen] = useState(false);
 
   const {
     data: { pages } = {},
@@ -47,34 +50,39 @@ const DashboardView = () => {
         </h1>
         <ul className="grid grid-cols-3 gap-[4rem]">
           <li>
-            <ActionCard onClick={() => alert("여행생성")} className="w-full" />
+            <ActionCard
+              onClick={() => setIsCreateFormOpen(true)}
+              className="w-full"
+            />
           </li>
           {allTripBoards.map((tripBoard) => (
             <li key={tripBoard.tripBoardId}>
-              <TravelBoard
-                data={{
-                  boardId: tripBoard.tripBoardId!,
-                  boardName: tripBoard.boardName!,
-                  destination: tripBoard.destination!,
-                  startDate: tripBoard.startDate?.toString()!,
-                  endDate: tripBoard.endDate?.toString()!,
-                  participantCount: tripBoard.participantCount!,
-                  participants:
-                    tripBoard.participants?.map((p) => ({
-                      userId: p.userId ?? 0,
-                      profileImageUrl: p.profileImageUrl ?? "",
-                      nickname: p.nickname ?? "",
-                      role: p.role ?? "MEMBER",
-                    })) ?? [],
-                  accommodationCount: tripBoard.accommodationCount!,
-                }}
-                // TODOT: 핸들러 함수 api 부착
-                onDeleteClick={() => alert("여행 삭제")}
-                onEditClick={() => alert("여행 수정")}
-                onExitClick={() => alert("여행 나가기")}
-                onInviteClick={() => alert("여행 초대")}
-                className="w-full"
-              />
+              <Link href={`/boards/${tripBoard.tripBoardId}/lists`} prefetch>
+                <TravelBoard
+                  data={{
+                    boardId: tripBoard.tripBoardId!,
+                    boardName: tripBoard.boardName!,
+                    destination: tripBoard.destination!,
+                    startDate: tripBoard.startDate?.toString()!,
+                    endDate: tripBoard.endDate?.toString()!,
+                    participantCount: tripBoard.participantCount!,
+                    participants:
+                      tripBoard.participants?.map((p) => ({
+                        userId: p.userId ?? 0,
+                        profileImageUrl: p.profileImageUrl ?? "",
+                        nickname: p.nickname ?? "",
+                        role: p.role ?? "MEMBER",
+                      })) ?? [],
+                    accommodationCount: tripBoard.accommodationCount!,
+                  }}
+                  // TODOT: 핸들러 함수 api 부착
+                  onDeleteClick={() => alert("여행 삭제")}
+                  onEditClick={() => alert("여행 수정")}
+                  onExitClick={() => alert("여행 나가기")}
+                  onInviteClick={() => alert("여행 초대")}
+                  className="w-full"
+                />
+              </Link>
             </li>
           ))}
         </ul>
@@ -86,6 +94,13 @@ const DashboardView = () => {
           </div>
         )}
       </section>
+      <Popup
+        title="새 여행 만들기"
+        active={isCreateFormOpen}
+        onClose={() => setIsCreateFormOpen(false)}
+      >
+        <BoardCreateForm className="min-w-[51.1rem]" />
+      </Popup>
     </main>
   );
 };

--- a/apps/web/src/domains/list/components/header-section/index.tsx
+++ b/apps/web/src/domains/list/components/header-section/index.tsx
@@ -1,18 +1,27 @@
 import type { TripBoardSummaryResponse } from "@ssok/api/schemas";
 import { Button, IcArrowLeft, IcPerson } from "@ssok/ui";
+import { useRouter } from "next/navigation";
 import { formatDate } from "@/shared/utils/date";
 
 const HeaderSection = (tripBoardDetail: TripBoardSummaryResponse) => {
+  const router = useRouter();
   const { boardName, startDate, endDate, participantCount, destination } =
     tripBoardDetail;
   const start = startDate ? new Date(startDate) : undefined;
   const end = endDate ? new Date(endDate) : undefined;
+
+  const onBackClick = () => {
+    router.push("/boards");
+  };
   return (
     <header className="flex w-full items-center justify-between p-2 pr-8 pl-2">
       {/* 헤더 좌측  */}
       <div className="flex items-center gap-[1.2rem]">
         <div className="flex items-center gap-[0.8rem]">
-          <IcArrowLeft width={24} height={24} className="text-neutral-40" />
+          <button type="button" onClick={onBackClick}>
+            <IcArrowLeft width={24} height={24} className="text-neutral-40" />
+          </button>
+
           <span className="text-body1-medi16 text-neutral-25">{boardName}</span>
         </div>
         <div className="flex items-center gap-[0.8rem]">


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 여행 목록에서, 새여행 추가 클릭시 모달을 통한 여행 생성을 연결했습니다 
- 여행 생성 후, 리다이렉트 되던 주소 뒤에 `/lists`를 추가하여 오류를 해결했습니다
- 여행 카드 선택시, `/lists` 페이지로 진입하도록 추가했습니다 
- `/lists` 페이지에서, 뒤로가기 선택시 `/boards` 페이지로 돌아가도록 설정했습니다 

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

[여행 카드 선택시, 리스트 페이지 진입 + 뒤로가기 연결]

https://github.com/user-attachments/assets/51e969ae-75c8-4382-84bb-c853fbf1367a

[모달을 통한, 여행 생성 추가 및 리스트 페이지 리다이렉트]

https://github.com/user-attachments/assets/d45aac09-9c7c-42b5-a168-4a7fcbd3507f



## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 새 기능
  - 대시보드에서 여행 보드 생성 플로우 추가: 액션 카드 클릭 시 모달이 열리고 생성 폼을 통해 보드 생성 가능.
  - 보드 생성 완료 후 /boards/{id}/lists로 자동 이동.
  - 대시보드의 각 보드를 클릭하면 /boards/{id}/lists로 이동하도록 링크 적용(프리페치 포함).
  - 리스트 화면 헤더에 뒤로가기 버튼 추가로 /boards로 손쉽게 이동 가능.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->