### PR TITLE
[Y26W2-328] fix(web): link 이동 이벤트 이벤트 전파 중지

### DIFF
--- a/packages/ui/src/components/travel-board/index.tsx
+++ b/packages/ui/src/components/travel-board/index.tsx
@@ -58,7 +58,9 @@ const TravelBoard = ({
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const dropdownWrapperRef = useRef<HTMLDivElement | null>(null);
 
-  const handleDropdownToggle = () => {
+  const handleDropdownToggle = (e: React.MouseEvent<HTMLButtonElement>) => {
+    e.stopPropagation();
+    e.preventDefault();
     setIsDropdownOpen((prev) => !prev);
   };
 
@@ -103,11 +105,7 @@ const TravelBoard = ({
             type="button"
             onMouseEnter={() => setMoreHover(true)}
             onMouseLeave={() => setMoreHover(false)}
-            onClick={(e) => {
-              e.stopPropagation();
-              e.preventDefault();
-              handleDropdownToggle();
-            }}
+            onClick={handleDropdownToggle}
             className="rounded-[1.2rem] p-[0.8rem] hover:bg-neutral-98 focus:bg-neutral-95"
           >
             <IcMore width={32} height={32} className="text-neutral-50" />

--- a/packages/ui/src/components/travel-board/index.tsx
+++ b/packages/ui/src/components/travel-board/index.tsx
@@ -103,7 +103,11 @@ const TravelBoard = ({
             type="button"
             onMouseEnter={() => setMoreHover(true)}
             onMouseLeave={() => setMoreHover(false)}
-            onClick={handleDropdownToggle}
+            onClick={(e) => {
+              e.stopPropagation();
+              e.preventDefault();
+              handleDropdownToggle();
+            }}
             className="rounded-[1.2rem] p-[0.8rem] hover:bg-neutral-98 focus:bg-neutral-95"
           >
             <IcMore width={32} height={32} className="text-neutral-50" />


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- Link 태그가 감싸져있어서, toggle Menu가 안열리는 현상을 해결했습니다! (이벤트 전파 방지) 

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 --> 
<img width="3360" height="1668" alt="image" src="https://github.com/user-attachments/assets/c70822b6-ad86-4338-8b9f-1429ee51c1d8" />


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 버그 수정
  * 여행 보드의 드롭다운 토글을 클릭하면 즉시 닫히던 문제를 수정했습니다. 이제 버튼 클릭 시 드롭다운이 안정적으로 열리고 닫힙니다.
  * 외부 영역 클릭 감지와의 충돌을 방지하여 의도치 않은 닫힘을 줄이고 일관된 동작을 보장합니다.
  * 불필요한 상호작용이 차단되어 클릭 응답성이 개선되고 전반적인 사용성이 향상되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->