### PR TITLE
[Y26W2-327] chore(web): 프로필 메뉴 z-index 조정

### DIFF
--- a/apps/web/src/shared/components/side-navigation/atom/profile-menu.tsx
+++ b/apps/web/src/shared/components/side-navigation/atom/profile-menu.tsx
@@ -66,7 +66,7 @@ const ProfileMenu = () => {
         {isMenuOpen && (
           <section
             className={cn(
-              "absolute bottom-0 left-[150%] z-[1] flex w-[30.2rem] flex-col gap-[2rem] rounded-[1.6rem] border border-neutral-90",
+              "absolute bottom-0 left-[150%] z-[3] flex w-[30.2rem] flex-col gap-[2rem] rounded-[1.6rem] border border-neutral-90",
               "bg-neutral-100 px-[0.8rem] py-[2.4rem] shadow-[4px_4px_8px_0_rgba(0,0,0,0.15)]",
             )}
           >


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 사이드바에서 등장하는, 프로필 메뉴의 z-index를 조정했습니다

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

<img width="1690" height="906" alt="스크린샷 2025-08-16 오후 6 44 32" src="https://github.com/user-attachments/assets/9f5b6b10-f396-4665-a409-6ea0934aabbf" />


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 프로필 메뉴 드롭다운이 다른 요소에 가려지거나 클릭이 어려웠던 문제를 해결했습니다. 이제 다양한 화면 크기와 스크롤 상황에서도 의도한 위치에 안정적으로 표시됩니다.

- 스타일
  - 드롭다운의 시각적 레이어 우선순위를 높여 겹침 현상을 최소화했습니다. 이를 통해 메뉴가 항상 최상단에서 명확하게 보이며 상호작용이 원활해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->