### PR TITLE
[Y26W2-322] feat(web): 보드 삭제하기, 나가기 Confirm 개발

### DIFF
--- a/apps/web/src/domains/dashboard/components/dashboard-trip-board/index.tsx
+++ b/apps/web/src/domains/dashboard/components/dashboard-trip-board/index.tsx
@@ -1,0 +1,130 @@
+"use client";
+
+import {
+  getGetTripBoardsQueryKey,
+  useDeleteTripBoard,
+  useLeaveTripBoard,
+} from "@ssok/api";
+import { Confirm, TravelBoard, useToggle } from "@ssok/ui";
+import { useQueryClient } from "@tanstack/react-query";
+import Link from "next/link";
+import useSession from "@/shared/hooks/use-session";
+import type { TripBoardSummary } from "../../types";
+
+export interface DashboardTripBoardProps {
+  data: TripBoardSummary;
+  className?: string;
+}
+
+const DashboardTripBoard = ({ data, className }: DashboardTripBoardProps) => {
+  const queryClient = useQueryClient();
+  const exitModal = useToggle(false);
+  const deleteModal = useToggle(false);
+  const { accessToken } = useSession({ required: true });
+
+  const { mutate: leaveTripBoard, isPending: isLeaving } = useLeaveTripBoard({
+    mutation: {
+      onSuccess: () => {
+        exitModal.deactivate();
+        queryClient.invalidateQueries({ queryKey: getGetTripBoardsQueryKey() });
+      },
+      onError: (error) => {
+        console.error("보드 나가기 실패:", error);
+      },
+    },
+    request: { headers: { Authorization: `Bearer ${accessToken}` } },
+  });
+
+  const { mutate: deleteTripBoard, isPending: isDeleting } = useDeleteTripBoard(
+    {
+      mutation: {
+        onSuccess: () => {
+          deleteModal.deactivate();
+          queryClient.invalidateQueries({
+            queryKey: getGetTripBoardsQueryKey(),
+          });
+        },
+        onError: (error) => {
+          console.error("보드 삭제 실패:", error);
+        },
+      },
+      request: { headers: { Authorization: `Bearer ${accessToken}` } },
+    },
+  );
+
+  const handleExitConfirm = () => {
+    if (!data.tripBoardId) {
+      return;
+    }
+    leaveTripBoard({
+      tripBoardId: data.tripBoardId,
+      data: { removeResources: false },
+    });
+  };
+
+  const handleDeleteConfirm = () => {
+    if (!data.tripBoardId) {
+      return;
+    }
+    deleteTripBoard({ tripBoardId: data.tripBoardId });
+  };
+
+  const handleCancel = () => {
+    if (!isLeaving && !isDeleting) {
+      exitModal.deactivate();
+      deleteModal.deactivate();
+    }
+  };
+
+  const travelBoardData = {
+    boardId: data.tripBoardId || 0,
+    boardName: data.boardName || "",
+    destination: data.destination || "",
+    startDate: data.startDate?.toString() || "",
+    endDate: data.endDate?.toString() || "",
+    participantCount: data.participantCount || 0,
+    participants:
+      data.participants?.map((p) => ({
+        userId: p.userId || 0,
+        profileImageUrl: p.profileImageUrl || "",
+        nickname: p.nickname || "",
+        role: p.role || "MEMBER",
+      })) || [],
+    accommodationCount: data.accommodationCount || 0,
+  };
+
+  return (
+    <>
+      <Link href={`/boards/${data.tripBoardId || 0}/lists`} prefetch>
+        <TravelBoard
+          data={travelBoardData}
+          onDeleteClick={() => deleteModal.activate()}
+          onEditClick={() => alert("여행 수정")}
+          onExitClick={() => exitModal.activate()}
+          onInviteClick={() => alert("여행 초대")}
+          className={className}
+        />
+      </Link>
+      <Confirm
+        active={exitModal.active}
+        title="여행에서 나갈까요?"
+        description={`'${data.boardName || "여행"}' 보드에서 정말 나가시겠어요? 나가도 내가 남긴 숙소 정보는 그대로 남아 있어요.`}
+        cancelText="닫기"
+        confirmText="나가기"
+        onCancel={isLeaving ? undefined : handleCancel}
+        onConfirm={isLeaving ? undefined : handleExitConfirm}
+      />
+      <Confirm
+        active={deleteModal.active}
+        title="여행을 모두에게 삭제할까요?"
+        description={`정말로 '${data.boardName || "여행"}' 보드를 삭제하시겠어요? 한 번 삭제하면 다시 복구할 수 없어요.`}
+        cancelText="닫기"
+        confirmText="삭제하기"
+        onCancel={isDeleting ? undefined : handleCancel}
+        onConfirm={isDeleting ? undefined : handleDeleteConfirm}
+      />
+    </>
+  );
+};
+
+export default DashboardTripBoard;

--- a/apps/web/src/domains/dashboard/types.ts
+++ b/apps/web/src/domains/dashboard/types.ts
@@ -1,7 +1,3 @@
-import type { TripBoardCreateRequest } from "@ssok/api/schemas";
-import type { DateRangeValue } from "@ssok/ui";
+import type { TripBoardSummaryResponse } from "@ssok/api/schemas";
 
-export interface BoardCreateFormData
-  extends Omit<TripBoardCreateRequest, "boardName" | "startDate" | "endDate"> {
-  dateRange: DateRangeValue;
-}
+export interface TripBoardSummary extends TripBoardSummaryResponse {}

--- a/apps/web/src/domains/dashboard/types.ts
+++ b/apps/web/src/domains/dashboard/types.ts
@@ -1,3 +1,12 @@
-import type { TripBoardSummaryResponse } from "@ssok/api/schemas";
+import type {
+  TripBoardCreateRequest,
+  TripBoardSummaryResponse,
+} from "@ssok/api/schemas";
+import type { DateRangeValue } from "@ssok/ui";
+
+export interface BoardCreateFormData
+  extends Omit<TripBoardCreateRequest, "boardName" | "startDate" | "endDate"> {
+  dateRange: DateRangeValue;
+}
 
 export interface TripBoardSummary extends TripBoardSummaryResponse {}

--- a/apps/web/src/domains/dashboard/views/dashboard-view.tsx
+++ b/apps/web/src/domains/dashboard/views/dashboard-view.tsx
@@ -1,12 +1,12 @@
 "use client";
 
 import { useGetTripBoardsInfinite } from "@ssok/api";
-import { ActionCard, Popup, TravelBoard } from "@ssok/ui";
-import Link from "next/link";
+import { ActionCard, Popup } from "@ssok/ui";
 import { useEffect, useState } from "react";
 import Header from "@/shared/components/header";
 import useSession from "@/shared/hooks/use-session";
 import BoardCreateForm from "../components/board-create-form";
+import DashboardTripBoard from "../components/dashboard-trip-board";
 
 const DashboardView = () => {
   const { accessToken } = useSession({ required: true });
@@ -57,32 +57,7 @@ const DashboardView = () => {
           </li>
           {allTripBoards.map((tripBoard) => (
             <li key={tripBoard.tripBoardId}>
-              <Link href={`/boards/${tripBoard.tripBoardId}/lists`} prefetch>
-                <TravelBoard
-                  data={{
-                    boardId: tripBoard.tripBoardId!,
-                    boardName: tripBoard.boardName!,
-                    destination: tripBoard.destination!,
-                    startDate: tripBoard.startDate?.toString()!,
-                    endDate: tripBoard.endDate?.toString()!,
-                    participantCount: tripBoard.participantCount!,
-                    participants:
-                      tripBoard.participants?.map((p) => ({
-                        userId: p.userId ?? 0,
-                        profileImageUrl: p.profileImageUrl ?? "",
-                        nickname: p.nickname ?? "",
-                        role: p.role ?? "MEMBER",
-                      })) ?? [],
-                    accommodationCount: tripBoard.accommodationCount!,
-                  }}
-                  // TODOT: 핸들러 함수 api 부착
-                  onDeleteClick={() => alert("여행 삭제")}
-                  onEditClick={() => alert("여행 수정")}
-                  onExitClick={() => alert("여행 나가기")}
-                  onInviteClick={() => alert("여행 초대")}
-                  className="w-full"
-                />
-              </Link>
+              <DashboardTripBoard data={tripBoard} className="w-full" />
             </li>
           ))}
         </ul>

--- a/packages/ui/src/components/action-option/index.tsx
+++ b/packages/ui/src/components/action-option/index.tsx
@@ -1,3 +1,4 @@
+import type { KeyboardEvent, MouseEvent, PropsWithChildren } from "react";
 import { cn } from "@/utils";
 
 interface DropdownProps {
@@ -5,14 +6,16 @@ interface DropdownProps {
   children: React.ReactNode;
 }
 
-interface DropdownOptionProps {
-  onClick: () => void;
-  children: React.ReactNode;
-  icon: React.ReactNode;
-}
+interface DropdownOptionProps
+  extends PropsWithChildren<{
+    onClick: (e: MouseEvent | KeyboardEvent) => void;
+    icon: React.ReactNode;
+  }> {}
 
 const DropdownMenu = ({ isOpen, children }: DropdownProps) => {
-  if (!isOpen) return null;
+  if (!isOpen) {
+    return null;
+  }
 
   return (
     <ul className="absolute top-[7.3rem] right-0 z-1 flex flex-col items-start gap-[0.8rem] rounded-[1.2rem] border border-neutral-70 bg-primary-100 p-[0.8rem] shadow-[4px_4px_8px_0_rgba(0,0,0,0.15)]">
@@ -25,7 +28,7 @@ const DropdownOption = ({ onClick, children, icon }: DropdownOptionProps) => {
   const handleKeyDown = (e: React.KeyboardEvent) => {
     if (e.key === "Enter" || e.key === " ") {
       e.preventDefault();
-      onClick?.();
+      onClick?.(e);
     }
   };
   return (

--- a/packages/ui/src/components/confirm/index.tsx
+++ b/packages/ui/src/components/confirm/index.tsx
@@ -32,7 +32,7 @@ const Confirm = ({
       {/** biome-ignore lint/a11y/useKeyWithClickEvents: onClick 사용하여 팝업 닫기 구현 */}
       <div
         className={cn(
-          "flex w-full min-w-[40rem] flex-col items-end gap-[3.2rem] px-[2.4rem] py-[2rem]",
+          "flex w-full max-w-[40rem] flex-col items-end gap-[3.2rem] px-[2.4rem] py-[2rem]",
           "rounded-[1.2rem] border border-neutral-90 bg-white shadow-[4px_4px_8px_0px_rgba(0,0,0,0.15)]",
           className,
         )}

--- a/packages/ui/src/components/travel-board/index.tsx
+++ b/packages/ui/src/components/travel-board/index.tsx
@@ -1,5 +1,5 @@
 "use client";
-import { useRef, useState } from "react";
+import { type MouseEvent, useRef, useState } from "react";
 import { useOutsideClickEffect } from "react-simplikit";
 import IcBookmark from "@/assets/icons/ic_bookmark.svg?react";
 import IcDelete from "@/assets/icons/ic_delete.svg?react";
@@ -58,7 +58,7 @@ const TravelBoard = ({
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
   const dropdownWrapperRef = useRef<HTMLDivElement | null>(null);
 
-  const handleDropdownToggle = (e: React.MouseEvent<HTMLButtonElement>) => {
+  const handleDropdownToggle = (e: MouseEvent<HTMLButtonElement>) => {
     e.stopPropagation();
     e.preventDefault();
     setIsDropdownOpen((prev) => !prev);
@@ -112,16 +112,44 @@ const TravelBoard = ({
           </button>
           {/* 드롭다운 */}
           <ActionOption.Menu isOpen={isDropdownOpen}>
-            <ActionOption.Option onClick={onInviteClick} icon={<IcInvite />}>
+            <ActionOption.Option
+              onClick={(e) => {
+                e.stopPropagation();
+                e.preventDefault();
+                onInviteClick();
+              }}
+              icon={<IcInvite />}
+            >
               멤버 초대하기
             </ActionOption.Option>
-            <ActionOption.Option onClick={onEditClick} icon={<IcEdit />}>
+            <ActionOption.Option
+              onClick={(e) => {
+                e.stopPropagation();
+                e.preventDefault();
+                onEditClick();
+              }}
+              icon={<IcEdit />}
+            >
               수정하기
             </ActionOption.Option>
-            <ActionOption.Option onClick={onExitClick} icon={<IcExit />}>
+            <ActionOption.Option
+              onClick={(e) => {
+                e.stopPropagation();
+                e.preventDefault();
+                onExitClick();
+              }}
+              icon={<IcExit />}
+            >
               나가기
             </ActionOption.Option>
-            <ActionOption.Option onClick={onDeleteClick} icon={<IcDelete />}>
+            <ActionOption.Option
+              onClick={(e) => {
+                e.stopPropagation();
+                e.preventDefault();
+                onDeleteClick();
+              }}
+              icon={<IcDelete />}
+            >
               삭제하기
             </ActionOption.Option>
           </ActionOption.Menu>


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 보드 나가기, 보드 삭제하기 Confirm 개발을 진행했습니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

| 나가기 | 삭제하기 |
| - | - |
| <img width="1278" height="962" alt="CleanShot 2025-08-17 at 00 14 46" src="https://github.com/user-attachments/assets/90d345fa-a66f-474f-bcb2-346735792aa4" /> | <img width="1278" height="962" alt="CleanShot 2025-08-17 at 00 15 24" src="https://github.com/user-attachments/assets/62539bb1-d3fe-4783-a35e-1892b262944d" /> |


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 대시보드에 새 DashboardTripBoard 카드 컴포넌트 추가 및 카드 내 나가기/삭제 확인 모달 도입(작업 중 확인 버튼 비활성화).
  - 요약형 TripBoardSummary 타입 공개 추가.
- 버그 수정
  - 드롭다운 옵션의 키/클릭 이벤트 전달 개선으로 불필요한 링크 이동/카드 클릭 방지.
- 리팩터링
  - 대시보드 항목 렌더링을 전용 컴포넌트로 분리해 데이터 흐름 및 상태 단순화.
  - ActionOption.Option의 onClick 시그니처가 이벤트 인자 수신으로 변경(호환성 영향).
- 스타일
  - Confirm 모달 너비를 최대 40rem로 제한해 작은 화면에서 유연하게 표시.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->