### PR TITLE
[Y26W2-337] feat(web): Trip board 공유하기 

### DIFF
--- a/apps/web/src/domains/dashboard/components/board-invite-modal/index.tsx
+++ b/apps/web/src/domains/dashboard/components/board-invite-modal/index.tsx
@@ -1,3 +1,4 @@
+import { useGetUserInfo } from "@ssok/api";
 import type { ParticipantProfileResponse } from "@ssok/api/schemas";
 import {
   AvatarProfile,
@@ -31,9 +32,17 @@ const BoardInviteModal = ({
     isCopyBtnClicked,
     isLoading,
     isFetching,
+    accessToken,
     handleInviteEnabledToggle,
     handleCopyInviteLink,
   } = useBoardInvite(tripBoardId, participants.length);
+
+  const { data: userInfo } = useGetUserInfo({
+    query: { enabled: !!accessToken },
+    request: { headers: { Authorization: `Bearer ${accessToken}` } },
+  });
+
+  const userNickname = userInfo?.data.result?.nickname;
 
   return (
     <section className={`flex flex-col gap-[4.8rem] ${className}`}>
@@ -90,7 +99,7 @@ const BoardInviteModal = ({
         <h2 className="text-heading2-semi18 text-neutral-30">
           이 여행에 함께하는 멤버들
         </h2>
-        <p className="text-body2-regular14 text-neutral-40">
+        <p className="mb-[0.5rem] text-body2-regular14 text-neutral-40">
           {participants?.length || 0}명 참여 중
         </p>
         <ul className="mb-[1.2rem] grid grid-cols-2 gap-x-[2.4rem] gap-y-[1.2rem]">
@@ -100,9 +109,12 @@ const BoardInviteModal = ({
               className="flex items-center gap-[0.8rem] text-body2-regular14 text-neutral-40"
             >
               <AvatarProfile size={32} imgUrl={participant?.profileImageUrl} />
-              <div>
+              <div className="flex gap-[0.2rem]">
                 <span className="text-body2-medi14 text-neutral-25">
                   {participant?.nickname}
+                </span>
+                <span className="text-body2-medi14 text-neutral-50">
+                  {userNickname === participant?.nickname && " (나)"}
                 </span>
               </div>
             </li>

--- a/apps/web/src/domains/dashboard/components/board-invite-modal/index.tsx
+++ b/apps/web/src/domains/dashboard/components/board-invite-modal/index.tsx
@@ -1,0 +1,83 @@
+import type { ParticipantProfileResponse } from "@ssok/api/schemas";
+import { AvatarProfile, Button, Switch, TextField } from "@ssok/ui";
+import { useState } from "react";
+
+interface BoardInviteModalProps {
+  className?: string;
+  tripBoardId: number;
+  participants: ParticipantProfileResponse[];
+}
+
+const BoardInviteModal = ({
+  className,
+  tripBoardId,
+  participants,
+}: BoardInviteModalProps) => {
+  const [isInviteEnabled, setIsInviteEnabled] = useState(true);
+
+  console.log(tripBoardId);
+  const handleInviteEnabledToggle = (checked: boolean) => {
+    setIsInviteEnabled(checked);
+  };
+  return (
+    <section className={`flex flex-col gap-[4.8rem] ${className}`}>
+      {/* 링크 만들기 */}
+      <div className="flex flex-col gap-[0.8rem]">
+        <h2 className="text-heading2-semi18 text-neutral-30">링크 만들기</h2>
+        <p className="text-body2-regular14 text-neutral-40">
+          본인을 포함해 최대 10명까지 참여할 수 있어요.
+        </p>
+        <div className="flex gap-[0.4rem]">
+          <TextField
+            value="https://www.ssok.info/qJPdkbu1WeXDNEDahu4DYe/%E"
+            disabled
+          />
+          <Button size="lg" variant="primary" onClick={() => {}}>
+            링크 복사
+          </Button>
+        </div>
+      </div>
+      {/* 초대 활성화하기 */}
+      <div className="flex justify-between gap-[0.8rem]">
+        <div className="flex flex-col gap-[0.4rem]">
+          <h2 className="text-heading2-semi18 text-neutral-30">
+            초대 활성화하기
+          </h2>
+          <p className="text-body2-regular14 text-neutral-40">
+            이 링크로 새 멤버를 초대할 수 있어요.
+          </p>
+        </div>
+        <Switch
+          isActive={isInviteEnabled}
+          onChange={handleInviteEnabledToggle}
+        />
+      </div>
+      {/* 여행 멤버들 */}
+      <div className="flex flex-col gap-[0.8rem]">
+        <h2 className="text-heading2-semi18 text-neutral-30">
+          이 여행에 함께하는 멤버들
+        </h2>
+        <p className="text-body2-regular14 text-neutral-40">
+          {participants?.length || 0}명 참여 중
+        </p>
+        <ul className="mb-[1.2rem] grid grid-cols-2 gap-x-[2.4rem] gap-y-[1.2rem]">
+          {participants?.map((participant) => (
+            <li
+              key={participant?.userId}
+              className="flex items-center gap-[0.8rem] text-body2-regular14 text-neutral-40"
+            >
+              <AvatarProfile size={32} imgUrl={participant?.profileImageUrl} />
+              <div>
+                <span className="text-body2-medi14 text-neutral-25">
+                  {participant?.nickname}
+                </span>
+              </div>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </section>
+  );
+};
+
+export default BoardInviteModal;

--- a/apps/web/src/domains/dashboard/components/board-invite-modal/index.tsx
+++ b/apps/web/src/domains/dashboard/components/board-invite-modal/index.tsx
@@ -1,6 +1,15 @@
+import { useGetInvitationCode, useToggleInvitationActive } from "@ssok/api";
 import type { ParticipantProfileResponse } from "@ssok/api/schemas";
-import { AvatarProfile, Button, Switch, TextField } from "@ssok/ui";
-import { useState } from "react";
+import {
+  AvatarProfile,
+  Button,
+  IcCheckFill,
+  Switch,
+  TextField,
+  useToast,
+} from "@ssok/ui";
+import { useEffect, useState } from "react";
+import useSession from "@/shared/hooks/use-session";
 
 interface BoardInviteModalProps {
   className?: string;
@@ -8,32 +17,101 @@ interface BoardInviteModalProps {
   participants: ParticipantProfileResponse[];
 }
 
+const SkeletonTextField = () => (
+  <div className="flex w-full gap-[0.4rem]">
+    <div className="w-full animate-pulse rounded-lg bg-neutral-95" />
+  </div>
+);
+
 const BoardInviteModal = ({
   className,
   tripBoardId,
   participants,
 }: BoardInviteModalProps) => {
-  const [isInviteEnabled, setIsInviteEnabled] = useState(true);
+  const { accessToken } = useSession({ required: true });
+  const { toast } = useToast();
+  const {
+    data: invitationCode,
+    isLoading,
+    isFetching,
+  } = useGetInvitationCode(tripBoardId, {
+    query: {
+      enabled: !!accessToken,
+    },
+    request: { headers: { Authorization: `Bearer ${accessToken}` } },
+  });
+  const inviteData = invitationCode?.data.result;
+  const inviteLink = `https://www.ssok.info/boards/${tripBoardId}?code=${inviteData?.invitationCode}`;
 
-  console.log(tripBoardId);
-  const handleInviteEnabledToggle = (checked: boolean) => {
-    setIsInviteEnabled(checked);
+  const { mutateAsync: toggleInviteActive } = useToggleInvitationActive({
+    request: { headers: { Authorization: `Bearer ${accessToken}` } },
+  });
+
+  const [isInviteEnabled, setIsInviteEnabled] = useState(inviteData?.isActive);
+  const [isCopyBtnClicked, setIsCopyBtnClicked] = useState(false);
+  useEffect(() => {
+    setIsInviteEnabled(participants.length < 10 && inviteData?.isActive);
+  }, [inviteData?.isActive, participants.length]);
+
+  const handleInviteEnabledToggle = async () => {
+    try {
+      const res = await toggleInviteActive({ tripBoardId });
+      const active = res.data.result?.isActive;
+
+      setIsInviteEnabled(active);
+
+      toast.success(
+        active ? "초대가 활성화되었어요" : "초대가 비활성화되었어요",
+      );
+    } catch (_error) {
+      console.log("초대 상태를 변경하는 중 오류가 발생했어요", _error);
+    }
   };
+
+  const handleCopyInviteLink = async () => {
+    if (!inviteLink || !isInviteEnabled) return;
+
+    await navigator.clipboard.writeText(inviteLink);
+    setIsCopyBtnClicked(true);
+    toast.success("링크가 복사되었어요");
+    setTimeout(() => {
+      setIsCopyBtnClicked(false);
+    }, 2000);
+  };
+
   return (
     <section className={`flex flex-col gap-[4.8rem] ${className}`}>
       {/* 링크 만들기 */}
       <div className="flex flex-col gap-[0.8rem]">
         <h2 className="text-heading2-semi18 text-neutral-30">링크 만들기</h2>
         <p className="text-body2-regular14 text-neutral-40">
-          본인을 포함해 최대 10명까지 참여할 수 있어요.
+          {isInviteEnabled
+            ? "본인을 포함해 최대 10명까지 참여할 수 있어요."
+            : "초대 링크가 비활성화되어 있어요. 사용하려면 다시 활성화해주세요."}
         </p>
         <div className="flex gap-[0.4rem]">
-          <TextField
-            value="https://www.ssok.info/qJPdkbu1WeXDNEDahu4DYe/%E"
-            disabled
-          />
-          <Button size="lg" variant="primary" onClick={() => {}}>
-            링크 복사
+          {isLoading || isFetching ? (
+            <SkeletonTextField />
+          ) : (
+            <TextField
+              value={isInviteEnabled ? inviteLink : ""}
+              placeholder={inviteLink}
+              disabled
+            />
+          )}
+          <Button
+            size="lg"
+            variant="primary"
+            onClick={handleCopyInviteLink}
+            disabled={!isInviteEnabled || participants.length >= 10}
+          >
+            {isCopyBtnClicked ? (
+              <span className="flex gap-[0.8rem] text-body1-bold16 text-primary100">
+                <IcCheckFill /> 복사됨
+              </span>
+            ) : (
+              "링크 복사"
+            )}
           </Button>
         </div>
       </div>
@@ -44,11 +122,13 @@ const BoardInviteModal = ({
             초대 활성화하기
           </h2>
           <p className="text-body2-regular14 text-neutral-40">
-            이 링크로 새 멤버를 초대할 수 있어요.
+            {isInviteEnabled
+              ? "이 링크로 새 멤버를 초대할 수 있어요."
+              : "더 이상 이 링크로 멤버를 초대할 수 없어요."}
           </p>
         </div>
         <Switch
-          isActive={isInviteEnabled}
+          isActive={isInviteEnabled ?? true}
           onChange={handleInviteEnabledToggle}
         />
       </div>

--- a/apps/web/src/domains/dashboard/hooks/use-invite.ts
+++ b/apps/web/src/domains/dashboard/hooks/use-invite.ts
@@ -1,0 +1,74 @@
+import { useGetInvitationCode, useToggleInvitationActive } from "@ssok/api";
+import { useToast } from "@ssok/ui";
+import { useEffect, useState } from "react";
+import useSession from "@/shared/hooks/use-session";
+
+export const useBoardInvite = (
+  tripBoardId: number,
+  participantsLength: number,
+) => {
+  const { accessToken } = useSession({ required: true });
+  const { toast } = useToast();
+
+  const {
+    data: invitationCode,
+    isLoading,
+    isFetching,
+  } = useGetInvitationCode(tripBoardId, {
+    query: { enabled: !!accessToken },
+    request: { headers: { Authorization: `Bearer ${accessToken}` } },
+  });
+
+  const inviteData = invitationCode?.data.result;
+  const inviteLink = `https://www.ssok.info/boards/${tripBoardId}?code=${inviteData?.invitationCode}`;
+
+  const { mutateAsync: toggleInviteActive } = useToggleInvitationActive({
+    request: { headers: { Authorization: `Bearer ${accessToken}` } },
+  });
+
+  const [isInviteEnabled, setIsInviteEnabled] = useState(inviteData?.isActive);
+  const [isCopyBtnClicked, setIsCopyBtnClicked] = useState(false);
+
+  // 초대 활성화 초기화 & participants 길이 반영
+  useEffect(() => {
+    setIsInviteEnabled(participantsLength < 10 && inviteData?.isActive);
+  }, [inviteData?.isActive, participantsLength]);
+
+  const handleInviteEnabledToggle = async () => {
+    try {
+      const res = await toggleInviteActive({ tripBoardId });
+      const active = res.data.result?.isActive;
+
+      setIsInviteEnabled(active);
+
+      toast.success(
+        active ? "초대가 활성화되었어요" : "초대가 비활성화되었어요",
+      );
+    } catch (error) {
+      console.error("초대 상태를 변경하는 중 오류", error);
+    }
+  };
+
+  const handleCopyInviteLink = async () => {
+    if (!inviteLink || !isInviteEnabled) return;
+
+    try {
+      await navigator.clipboard.writeText(inviteLink);
+      setIsCopyBtnClicked(true);
+      toast.success("링크가 복사되었어요");
+      // setTimeout(() => setIsCopyBtnClicked(false), 2000);
+    } catch (_error) {
+      console.error("링크 복사에 실패했어요", _error);
+    }
+  };
+
+  return {
+    inviteLink,
+    isInviteEnabled,
+    isCopyBtnClicked,
+    isLoading,
+    isFetching,
+    handleInviteEnabledToggle,
+    handleCopyInviteLink,
+  };
+};

--- a/apps/web/src/domains/dashboard/hooks/use-invite.ts
+++ b/apps/web/src/domains/dashboard/hooks/use-invite.ts
@@ -70,5 +70,6 @@ export const useBoardInvite = (
     isFetching,
     handleInviteEnabledToggle,
     handleCopyInviteLink,
+    accessToken,
   };
 };

--- a/apps/web/src/domains/dashboard/hooks/use-invite.ts
+++ b/apps/web/src/domains/dashboard/hooks/use-invite.ts
@@ -1,5 +1,10 @@
-import { useGetInvitationCode, useToggleInvitationActive } from "@ssok/api";
+import {
+  getGetInvitationCodeQueryKey,
+  useGetInvitationCode,
+  useToggleInvitationActive,
+} from "@ssok/api";
 import { useToast } from "@ssok/ui";
+import { useQueryClient } from "@tanstack/react-query";
 import { useEffect, useState } from "react";
 import useSession from "@/shared/hooks/use-session";
 
@@ -9,7 +14,7 @@ export const useBoardInvite = (
 ) => {
   const { accessToken } = useSession({ required: true });
   const { toast } = useToast();
-
+  const queryClient = useQueryClient();
   const {
     data: invitationCode,
     isLoading,
@@ -44,6 +49,9 @@ export const useBoardInvite = (
       toast.success(
         active ? "초대가 활성화되었어요" : "초대가 비활성화되었어요",
       );
+      queryClient.refetchQueries({
+        queryKey: getGetInvitationCodeQueryKey(tripBoardId),
+      });
     } catch (error) {
       console.error("초대 상태를 변경하는 중 오류", error);
     }

--- a/apps/web/src/domains/dashboard/hooks/use-invite.ts
+++ b/apps/web/src/domains/dashboard/hooks/use-invite.ts
@@ -56,7 +56,7 @@ export const useBoardInvite = (
       await navigator.clipboard.writeText(inviteLink);
       setIsCopyBtnClicked(true);
       toast.success("링크가 복사되었어요");
-      // setTimeout(() => setIsCopyBtnClicked(false), 2000);
+      setTimeout(() => setIsCopyBtnClicked(false), 2000);
     } catch (_error) {
       console.error("링크 복사에 실패했어요", _error);
     }

--- a/apps/web/src/domains/dashboard/views/dashboard-view.tsx
+++ b/apps/web/src/domains/dashboard/views/dashboard-view.tsx
@@ -14,6 +14,12 @@ import BoardCreateForm from "../components/board-create-form";
 import BoardEditForm from "../components/board-edit-form";
 import BoardInviteModal from "../components/board-invite-modal";
 
+const popupTitles: Record<string, string> = {
+  createForm: "새 여행 만들기",
+  editForm: "여행 보드 수정하기",
+  inviteModal: "멤버 초대하기",
+};
+
 const DashboardView = () => {
   const { accessToken } = useSession({ required: true });
   const [modalState, setModalState] = useState<
@@ -141,11 +147,7 @@ const DashboardView = () => {
         )}
       </section>
       <Popup
-        title={
-          modalState?.type === "createForm"
-            ? "새 여행 만들기"
-            : "여행 보드 수정하기"
-        }
+        title={popupTitles[modalState?.type || "createForm"]}
         active={
           !!modalState &&
           (modalState.type === "createForm" ||

--- a/apps/web/src/domains/dashboard/views/dashboard-view.tsx
+++ b/apps/web/src/domains/dashboard/views/dashboard-view.tsx
@@ -1,7 +1,10 @@
 "use client";
 
 import { useGetTripBoardsInfinite } from "@ssok/api";
-import type { TripBoardUpdateRequest } from "@ssok/api/schemas";
+import type {
+  ParticipantProfileResponse,
+  TripBoardUpdateRequest,
+} from "@ssok/api/schemas";
 import { ActionCard, Popup, TravelBoard } from "@ssok/ui";
 import Link from "next/link";
 import { useEffect, useState } from "react";
@@ -9,11 +12,17 @@ import Header from "@/shared/components/header";
 import useSession from "@/shared/hooks/use-session";
 import BoardCreateForm from "../components/board-create-form";
 import BoardEditForm from "../components/board-edit-form";
+import BoardInviteModal from "../components/board-invite-modal";
 
 const DashboardView = () => {
   const { accessToken } = useSession({ required: true });
   const [modalState, setModalState] = useState<
     | { type: "createForm" }
+    | {
+        type: "inviteModal";
+        tripBoardId: number;
+        participants: ParticipantProfileResponse[];
+      }
     | { type: "editForm"; tripBoardId: number; data: TripBoardUpdateRequest }
     | null
   >(null);
@@ -54,6 +63,13 @@ const DashboardView = () => {
 
   const handleCreateModal = () => {
     setModalState({ type: "createForm" });
+  };
+
+  const handleInviteModal = (
+    tripBoardId: number,
+    participants: ParticipantProfileResponse[],
+  ) => {
+    setModalState({ type: "inviteModal", tripBoardId, participants });
   };
 
   const handleModalClose = () => {
@@ -104,7 +120,12 @@ const DashboardView = () => {
                     })
                   }
                   onExitClick={() => alert("여행 나가기")}
-                  onInviteClick={() => alert("여행 초대")}
+                  onInviteClick={() =>
+                    handleInviteModal(
+                      tripBoard.tripBoardId!,
+                      tripBoard.participants!,
+                    )
+                  }
                   className="w-full"
                 />
               </Link>
@@ -127,7 +148,9 @@ const DashboardView = () => {
         }
         active={
           !!modalState &&
-          (modalState.type === "createForm" || modalState.type === "editForm")
+          (modalState.type === "createForm" ||
+            modalState.type === "editForm" ||
+            modalState.type === "inviteModal")
         }
         onClose={() => handleModalClose()}
       >
@@ -140,6 +163,13 @@ const DashboardView = () => {
             tripBoardId={modalState.tripBoardId}
             data={modalState.data}
             handleModalClose={handleModalClose}
+          />
+        )}
+        {modalState?.type === "inviteModal" && (
+          <BoardInviteModal
+            tripBoardId={modalState.tripBoardId}
+            participants={modalState.participants}
+            className="min-w-[51.1rem]"
           />
         )}
       </Popup>

--- a/apps/web/src/domains/list/components/header-section/index.tsx
+++ b/apps/web/src/domains/list/components/header-section/index.tsx
@@ -1,14 +1,24 @@
 import type { TripBoardSummaryResponse } from "@ssok/api/schemas";
-import { Button, IcArrowLeft, IcPerson } from "@ssok/ui";
+import { Button, IcArrowLeft, IcPerson, Popup } from "@ssok/ui";
 import { useRouter } from "next/navigation";
+import { useState } from "react";
+import BoardInviteModal from "@/domains/dashboard/components/board-invite-modal";
 import { formatDate } from "@/shared/utils/date";
 
 const HeaderSection = (tripBoardDetail: TripBoardSummaryResponse) => {
   const router = useRouter();
-  const { boardName, startDate, endDate, participantCount, destination } =
-    tripBoardDetail;
+  const {
+    boardName,
+    startDate,
+    endDate,
+    participantCount,
+    destination,
+    participants,
+    tripBoardId,
+  } = tripBoardDetail;
   const start = startDate ? new Date(startDate) : undefined;
   const end = endDate ? new Date(endDate) : undefined;
+  const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
 
   const onBackClick = () => {
     router.push("/boards");
@@ -41,10 +51,25 @@ const HeaderSection = (tripBoardDetail: TripBoardSummaryResponse) => {
             {participantCount}
           </p>
         </span>
-        <Button size="xxs" variant="black">
+        <Button
+          size="xxs"
+          variant="black"
+          onClick={() => setIsInviteModalOpen(true)}
+        >
           초대하기
         </Button>
       </div>
+      <Popup
+        title="멤버 초대하기"
+        active={isInviteModalOpen}
+        onClose={() => setIsInviteModalOpen(false)}
+      >
+        <BoardInviteModal
+          className="min-w-[51.1rem]"
+          tripBoardId={tripBoardId || 0}
+          participants={participants || []}
+        />
+      </Popup>
     </header>
   );
 };

--- a/apps/web/src/domains/list/components/header-section/index.tsx
+++ b/apps/web/src/domains/list/components/header-section/index.tsx
@@ -1,7 +1,6 @@
 import type { TripBoardSummaryResponse } from "@ssok/api/schemas";
-import { Button, IcArrowLeft, IcPerson, Popup } from "@ssok/ui";
+import { Button, IcArrowLeft, IcPerson, Popup, useToggle } from "@ssok/ui";
 import { useRouter } from "next/navigation";
-import { useState } from "react";
 import BoardInviteModal from "@/domains/dashboard/components/board-invite-modal";
 import { formatDate } from "@/shared/utils/date";
 
@@ -18,7 +17,7 @@ const HeaderSection = (tripBoardDetail: TripBoardSummaryResponse) => {
   } = tripBoardDetail;
   const start = startDate ? new Date(startDate) : undefined;
   const end = endDate ? new Date(endDate) : undefined;
-  const [isInviteModalOpen, setIsInviteModalOpen] = useState(false);
+  const { active, activate, deactivate } = useToggle(false);
 
   const onBackClick = () => {
     router.push("/boards");
@@ -51,19 +50,11 @@ const HeaderSection = (tripBoardDetail: TripBoardSummaryResponse) => {
             {participantCount}
           </p>
         </span>
-        <Button
-          size="xxs"
-          variant="black"
-          onClick={() => setIsInviteModalOpen(true)}
-        >
+        <Button size="xxs" variant="black" onClick={activate}>
           초대하기
         </Button>
       </div>
-      <Popup
-        title="멤버 초대하기"
-        active={isInviteModalOpen}
-        onClose={() => setIsInviteModalOpen(false)}
-      >
+      <Popup title="멤버 초대하기" active={active} onClose={deactivate}>
         <BoardInviteModal
           className="min-w-[51.1rem]"
           tripBoardId={tripBoardId || 0}

--- a/packages/ui/src/components/button/button.variant.ts
+++ b/packages/ui/src/components/button/button.variant.ts
@@ -56,7 +56,7 @@ export const button = cva(
   },
 );
 
-export const buttonText = cva("m-0 text-center", {
+export const buttonText = cva("m-0 w-max whitespace-nowrap text-center", {
   variants: {
     size: {
       xxs: "text-caption1-semi12",

--- a/packages/ui/src/components/button/index.tsx
+++ b/packages/ui/src/components/button/index.tsx
@@ -41,7 +41,9 @@ const Button = ({
       {...props}
     >
       {icon && <>{icon}</>}
-      <span className={buttonText({ size })}>{children}</span>
+      <span className={cn(buttonText({ size }), !icon && "px-[5.5px]")}>
+        {children}
+      </span>
       {additionalText && (
         <span className="text-body2-medi14">{additionalText}</span>
       )}

--- a/packages/ui/src/components/switch/index.tsx
+++ b/packages/ui/src/components/switch/index.tsx
@@ -1,0 +1,31 @@
+import { cn } from "@/utils";
+
+export interface SwitchProps {
+  className?: string;
+  onChange: (checked: boolean) => void;
+  isActive: boolean;
+}
+
+const Switch = ({ onChange, isActive }: SwitchProps) => {
+  return (
+    <button
+      type="button"
+      onClick={() => onChange(!isActive)}
+      className={cn(
+        `h-[3.2rem] w-[5.6rem]`,
+        `relative flex items-center rounded-full p-[0.4rem] transition-colors`,
+        isActive ? "bg-primary" : "bg-neutral-90",
+      )}
+    >
+      <div
+        className={cn(
+          `h-[2.4rem] w-[2.4rem]`,
+          `rounded-full bg-primary-100 transition-transform`,
+          isActive ? "translate-x-[2.4rem]" : "translate-x-0",
+        )}
+      />
+    </button>
+  );
+};
+
+export default Switch;

--- a/packages/ui/src/components/switch/switch.stories.tsx
+++ b/packages/ui/src/components/switch/switch.stories.tsx
@@ -1,0 +1,48 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import { useState } from "react";
+import Switch, { type SwitchProps } from ".";
+
+const meta: Meta<typeof Switch> = {
+  title: "Components/Switch",
+  component: Switch,
+  parameters: {
+    layout: "centered",
+  },
+  argTypes: {
+    isActive: {
+      control: "boolean",
+      description: "스위치의 현재 상태 (true=활성화, false=비활성화)",
+    },
+    onChange: {
+      action: "changed",
+      description: "스위치 상태가 변경될 때 실행되는 함수",
+    },
+    className: {
+      control: "text",
+      description: "추가적인 CSS 클래스",
+    },
+  },
+};
+export default meta;
+
+type Story = StoryObj<typeof Switch>;
+
+export const Default: Story = {
+  render: (args: SwitchProps) => {
+    const [active, setActive] = useState(args.isActive);
+
+    return (
+      <Switch
+        {...args}
+        isActive={active}
+        onChange={(checked) => {
+          setActive(checked);
+          args.onChange?.(checked);
+        }}
+      />
+    );
+  },
+  args: {
+    isActive: false,
+  },
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -134,6 +134,7 @@ export {
   default as LoadingIndicator,
   type LoadingIndicatorProps,
 } from "./components/loading-indicator";
+export { default as Switch, type SwitchProps } from "./components/switch";
 export { default as TextWithIcon } from "./components/text-with-icon";
 export {
   default as TravelBoard,


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 여행 멤버 초대의 역할을 하는 모달과, 내부 로직들을 연결했습니다. 
- switch를 package/ui 에 제작했습니다

- 초대링크를 파싱하는 상태 (code를 api로 받아오는 pending )를 고려하여, 임의로 스켈레톤 UI를 만들어서 랜더링했습니다!
- 초대 Toggle deActive / 참여 인원 10 명 이상인 경우 링크 복사 기능을 비활성화 했습니다  
- 초대하기 링크를 복사하는 경우 2초동안, 버튼 내부가 복사됨으로 바뀌도록 설정했습니다 


## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

숙소 리스트 뷰 - 멤버 초대하기

https://github.com/user-attachments/assets/f82a1450-28be-453f-af33-18454d673562


여행 보드 뷰 - 멤버 초대하기

https://github.com/user-attachments/assets/dd832e8f-499d-47e7-93ab-78c930cc31be


멤버가 여러명인 경우  (title 오타는 현재 수정되었습니다 )

<img width="1700" height="910" alt="스크린샷 2025-08-17 오후 7 07 35" src="https://github.com/user-attachments/assets/87588e9e-1b4f-4833-819f-ec8869bf5257" />


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신규 기능
  - 대시보드와 리스트 헤더에 멤버 초대 모달 추가: 초대 링크 생성/복사, 초대 활성화 전환, 참여자 목록 확인(본인 표시).
  - 초대 버튼 클릭 시 모달로 초대 흐름 시작.

- 스타일
  - 버튼 텍스트가 줄바꿈 없이 내용에 맞게 표시되도록 개선.
  - 아이콘 없는 버튼의 텍스트 좌우 여백 추가로 가독성 향상.
  - 토글 스위치 UI 추가.

- 문서
  - 스위치 컴포넌트 스토리북 스토리 추가(상호작용 데모 및 컨트롤 제공).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->