### PR TITLE
[Y26W2-339] feat(web): 여행 나가기, 삭제 action 이후 성공 toast 랜더링

### DIFF
--- a/apps/web/src/domains/dashboard/components/dashboard-trip-board/index.tsx
+++ b/apps/web/src/domains/dashboard/components/dashboard-trip-board/index.tsx
@@ -6,7 +6,7 @@ import {
   useLeaveTripBoard,
 } from "@ssok/api";
 import type { TripBoardUpdateRequest } from "@ssok/api/schemas";
-import { Confirm, Popup, TravelBoard, useToggle } from "@ssok/ui";
+import { Confirm, Popup, TravelBoard, useToast, useToggle } from "@ssok/ui";
 import { useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import useSession from "@/shared/hooks/use-session";
@@ -25,6 +25,7 @@ const DashboardTripBoard = ({ data, className }: DashboardTripBoardProps) => {
   const deleteModal = useToggle(false);
   const editModal = useToggle(false);
   const inviteModal = useToggle(false);
+  const { toast } = useToast();
   const { accessToken } = useSession({ required: true });
 
   const { mutate: leaveTripBoard, isPending: isLeaving } = useLeaveTripBoard({
@@ -32,6 +33,7 @@ const DashboardTripBoard = ({ data, className }: DashboardTripBoardProps) => {
       onSuccess: () => {
         exitModal.deactivate();
         queryClient.invalidateQueries({ queryKey: getGetTripBoardsQueryKey() });
+        toast.success("여행에서 나갔어요");
       },
       onError: (error) => {
         console.error("보드 나가기 실패:", error);
@@ -48,6 +50,7 @@ const DashboardTripBoard = ({ data, className }: DashboardTripBoardProps) => {
           queryClient.invalidateQueries({
             queryKey: getGetTripBoardsQueryKey(),
           });
+          toast.success("여행이 삭제되었어요");
         },
         onError: (error) => {
           console.error("보드 삭제 실패:", error);

--- a/apps/web/src/domains/dashboard/views/dashboard-view.tsx
+++ b/apps/web/src/domains/dashboard/views/dashboard-view.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useGetTripBoardsInfinite } from "@ssok/api";
-import { ActionCard, Popup } from "@ssok/ui";
+import { ActionCard, LoadingIndicator, Popup } from "@ssok/ui";
 import { useEffect, useState } from "react";
 import Header from "@/shared/components/header";
 import useSession from "@/shared/hooks/use-session";
@@ -61,13 +61,7 @@ const DashboardView = () => {
             </li>
           ))}
         </ul>
-        {isFetching && (
-          <div className="mt-[2rem] text-center">
-            <p className="text-body2-medi14 text-neutral-60">
-              데이터를 불러오는 중...
-            </p>
-          </div>
-        )}
+        <LoadingIndicator active={isFetching} />
       </section>
       <Popup
         title="새 여행 만들기"


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- tripBoard 나가기 / 삭제 api 성공시, toast 메시지를 띄울 수 있도록 작업했습니다 
- 여행 보드 무한스크롤에서 isFetching 상태에 대해서, LoadingIndicator를 적용하도록 했습니다 

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

| 여행 나가기 toast | 여행 삭제 toast |
| ----------- | ----------- |
| <img width="600" alt="스크린샷1" src="https://github.com/user-attachments/assets/683f8baa-e685-407f-80d6-bf27915633ca" /> | <img width="600" alt="스크린샷2" src="https://github.com/user-attachments/assets/caa90986-a6e8-4fab-9e1b-2f01c4ff084f" /> |



## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->
