### PR TITLE
[Y26W2-342] chore(api): openAPI 최신화 반영

### DIFF
--- a/packages/api/src/api/openapi.json
+++ b/packages/api/src/api/openapi.json
@@ -116,7 +116,7 @@
       "get": {
         "tags": ["비교표 API"],
         "summary": "비교표 조회",
-        "description": "비교표 메타 데이터와 포함된 숙소 정보 리스트를 조회합니다. (Authorization 헤더에 Bearer 토큰 필요)",
+        "description": "비교표 메타 데이터와 포함된 숙소 정보 리스트를 조회합니다. JWT 인증이 필요하며, 비교표 생성자 또는 여행보드 참여자만 접근 가능합니다.",
         "operationId": "getComparisonTable",
         "parameters": [
           {
@@ -129,7 +129,7 @@
         ],
         "responses": {
           "200": {
-            "description": "OK",
+            "description": "비교표 조회 성공",
             "content": {
               "*/*": {
                 "schema": {
@@ -724,6 +724,86 @@
             }
           }
         }
+      }
+    },
+    "/api/comparison/{tableId}/shared": {
+      "get": {
+        "tags": ["비교표 API"],
+        "summary": "shareCode를 통한 비교표 조회",
+        "description": "shareCode를 사용하여 인증 없이 비교표를 조회합니다. 유효한 shareCode가 필요합니다.",
+        "operationId": "getComparisonTableByShareCode",
+        "parameters": [
+          {
+            "name": "tableId",
+            "in": "path",
+            "description": "숙소가 포함된 테이블의 ID",
+            "required": true,
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "shareCode",
+            "in": "query",
+            "description": "비교표 공유 코드",
+            "required": true,
+            "schema": { "type": "string" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "비교표 조회 성공",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardResponseComparisonTableResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/comparison/trip-board/{tripBoardId}": {
+      "get": {
+        "tags": ["비교표 API"],
+        "summary": "여행보드의 비교표 리스트 조회",
+        "description": "특정 여행보드에 생성된 모든 비교표의 리스트를 무한스크롤 페이지네이션으로 조회합니다. 각 비교표의 기본 정보와 포함된 숙소 정보를 제공합니다.",
+        "operationId": "getComparisonTablesByTripBoard",
+        "parameters": [
+          {
+            "name": "tripBoardId",
+            "in": "path",
+            "description": "조회할 여행보드의 ID",
+            "required": true,
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "description": "페이지 번호 (0부터 시작)",
+            "required": true,
+            "schema": { "type": "integer" }
+          },
+          {
+            "name": "size",
+            "in": "query",
+            "description": "페이지 크기",
+            "required": true,
+            "schema": { "type": "integer" }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "비교표 리스트 조회 성공",
+            "content": {
+              "*/*": {
+                "schema": {
+                  "$ref": "#/components/schemas/StandardResponseComparisonTablePageResponse"
+                }
+              }
+            }
+          }
+        },
+        "security": [{ "JWT": [] }]
       }
     },
     "/api/comparison/factors": {
@@ -1546,6 +1626,7 @@
             "type": "array",
             "items": { "$ref": "#/components/schemas/AccommodationResponse" }
           },
+          "shareCode": { "type": "string" },
           "factorsList": {
             "type": "array",
             "items": {
@@ -1562,7 +1643,8 @@
               ]
             }
           },
-          "createdBy": { "type": "integer", "format": "int64" }
+          "createdBy": { "type": "integer", "format": "int64" },
+          "creatorName": { "type": "string" }
         }
       },
       "StandardResponseComparisonTableResponse": {
@@ -1764,6 +1846,75 @@
           },
           "result": {
             "$ref": "#/components/schemas/AuthorizeUrlResponse",
+            "description": "응답 결과 데이터"
+          }
+        }
+      },
+      "ComparisonTablePageResponse": {
+        "type": "object",
+        "properties": {
+          "comparisonTables": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/ComparisonTableSummaryResponse"
+            }
+          },
+          "hasNext": { "type": "boolean" }
+        }
+      },
+      "ComparisonTableSummaryResponse": {
+        "type": "object",
+        "description": "비교표 목록 조회 응답",
+        "properties": {
+          "tableId": {
+            "type": "integer",
+            "format": "int64",
+            "description": "비교표 ID",
+            "example": 1
+          },
+          "tableName": {
+            "type": "string",
+            "description": "비교표 이름",
+            "example": "제주도 숙소 비교"
+          },
+          "accommodationCount": {
+            "type": "integer",
+            "format": "int32",
+            "description": "포함된 숙소 개수",
+            "example": 3
+          },
+          "accommodationNames": {
+            "type": "array",
+            "description": "포함된 숙소 이름들",
+            "example": ["호텔 신라", "롯데 호텔", "그랜드 하이얏트"],
+            "items": { "type": "string" }
+          },
+          "lastModifiedAt": {
+            "type": "string",
+            "format": "date-time",
+            "description": "최근 수정일 (UTC)",
+            "example": "2025-08-15T08:30:00Z"
+          },
+          "shareCode": {
+            "type": "string",
+            "description": "공유 코드",
+            "example": "4473fa9aed7044c7a94fa6e99..",
+            "readOnly": true
+          }
+        }
+      },
+      "StandardResponseComparisonTablePageResponse": {
+        "type": "object",
+        "description": "API 응답의 표준 형식을 정의하는 클래스",
+        "properties": {
+          "responseType": {
+            "type": "string",
+            "description": "응답 유형",
+            "enum": ["SUCCESS", "ERROR"],
+            "example": "SUCCESS"
+          },
+          "result": {
+            "$ref": "#/components/schemas/ComparisonTablePageResponse",
             "description": "응답 결과 데이터"
           }
         }

--- a/packages/api/src/index.msw.ts
+++ b/packages/api/src/index.msw.ts
@@ -20,6 +20,7 @@ import type {
   StandardResponseBoolean,
   StandardResponseComparisonFactorList,
   StandardResponseComparisonTableDeleteResponse,
+  StandardResponseComparisonTablePageResponse,
   StandardResponseComparisonTableResponse,
   StandardResponseCreateComparisonTableResponse,
   StandardResponseInvitationCodeResponse,
@@ -529,6 +530,10 @@ export const getGetComparisonTableResponseMock = (
         })),
         undefined,
       ]),
+      shareCode: faker.helpers.arrayElement([
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
+        undefined,
+      ]),
       factorsList: faker.helpers.arrayElement([
         faker.helpers.arrayElements([
           "REVIEW_SCORE",
@@ -548,6 +553,10 @@ export const getGetComparisonTableResponseMock = (
           max: undefined,
           multipleOf: undefined,
         }),
+        undefined,
+      ]),
+      creatorName: faker.helpers.arrayElement([
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
         undefined,
       ]),
     },
@@ -920,6 +929,10 @@ export const getAddAccommodationToComparisonTableResponseMock = (
         })),
         undefined,
       ]),
+      shareCode: faker.helpers.arrayElement([
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
+        undefined,
+      ]),
       factorsList: faker.helpers.arrayElement([
         faker.helpers.arrayElements([
           "REVIEW_SCORE",
@@ -939,6 +952,10 @@ export const getAddAccommodationToComparisonTableResponseMock = (
           max: undefined,
           multipleOf: undefined,
         }),
+        undefined,
+      ]),
+      creatorName: faker.helpers.arrayElement([
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
         undefined,
       ]),
     },
@@ -1463,6 +1480,429 @@ export const getGetKakaoAuthorizeUrlResponseMock = (
     {
       authorizeUrl: faker.helpers.arrayElement([
         faker.string.alpha({ length: { min: 10, max: 20 } }),
+        undefined,
+      ]),
+    },
+    undefined,
+  ]),
+  ...overrideResponse,
+});
+
+export const getGetComparisonTableByShareCodeResponseMock = (
+  overrideResponse: Partial<StandardResponseComparisonTableResponse> = {},
+): StandardResponseComparisonTableResponse => ({
+  responseType: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(["SUCCESS", "ERROR"] as const),
+    undefined,
+  ]),
+  result: faker.helpers.arrayElement([
+    {
+      tableId: faker.helpers.arrayElement([
+        faker.number.int({
+          min: undefined,
+          max: undefined,
+          multipleOf: undefined,
+        }),
+        undefined,
+      ]),
+      tableName: faker.helpers.arrayElement([
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
+        undefined,
+      ]),
+      accommodationResponsesList: faker.helpers.arrayElement([
+        Array.from(
+          { length: faker.number.int({ min: 4, max: 4 }) },
+          (_, i) => i + 1,
+        ).map(() => ({
+          id: faker.helpers.arrayElement([
+            faker.number.int({
+              min: undefined,
+              max: undefined,
+              multipleOf: undefined,
+            }),
+            undefined,
+          ]),
+          url: faker.helpers.arrayElement([
+            faker.string.alpha({ length: { min: 10, max: 20 } }),
+            undefined,
+          ]),
+          siteName: faker.helpers.arrayElement([
+            faker.string.alpha({ length: { min: 10, max: 20 } }),
+            undefined,
+          ]),
+          logoUrl: faker.helpers.arrayElement([
+            faker.string.alpha({ length: { min: 10, max: 20 } }),
+            undefined,
+          ]),
+          memo: faker.helpers.arrayElement([
+            faker.string.alpha({ length: { min: 10, max: 20 } }),
+            undefined,
+          ]),
+          createdAt: faker.helpers.arrayElement([
+            new Date(`${faker.date.past().toISOString().split(".")[0]}Z`),
+            undefined,
+          ]),
+          updatedAt: faker.helpers.arrayElement([
+            new Date(`${faker.date.past().toISOString().split(".")[0]}Z`),
+            undefined,
+          ]),
+          createdBy: faker.helpers.arrayElement([
+            faker.number.int({
+              min: undefined,
+              max: undefined,
+              multipleOf: undefined,
+            }),
+            undefined,
+          ]),
+          tripBoardId: faker.helpers.arrayElement([
+            faker.number.int({
+              min: undefined,
+              max: undefined,
+              multipleOf: undefined,
+            }),
+            undefined,
+          ]),
+          accommodationName: faker.helpers.arrayElement([
+            faker.string.alpha({ length: { min: 10, max: 20 } }),
+            undefined,
+          ]),
+          images: faker.helpers.arrayElement([
+            Array.from(
+              { length: faker.number.int({ min: 4, max: 4 }) },
+              (_, i) => i + 1,
+            ).map(() => faker.string.alpha({ length: { min: 10, max: 20 } })),
+            undefined,
+          ]),
+          address: faker.helpers.arrayElement([
+            faker.string.alpha({ length: { min: 10, max: 20 } }),
+            undefined,
+          ]),
+          latitude: faker.helpers.arrayElement([
+            faker.number.float({
+              min: undefined,
+              max: undefined,
+              fractionDigits: 2,
+            }),
+            undefined,
+          ]),
+          longitude: faker.helpers.arrayElement([
+            faker.number.float({
+              min: undefined,
+              max: undefined,
+              fractionDigits: 2,
+            }),
+            undefined,
+          ]),
+          lowestPrice: faker.helpers.arrayElement([
+            faker.number.int({
+              min: undefined,
+              max: undefined,
+              multipleOf: undefined,
+            }),
+            undefined,
+          ]),
+          highestPrice: faker.helpers.arrayElement([
+            faker.number.int({
+              min: undefined,
+              max: undefined,
+              multipleOf: undefined,
+            }),
+            undefined,
+          ]),
+          currency: faker.helpers.arrayElement([
+            faker.string.alpha({ length: { min: 10, max: 20 } }),
+            undefined,
+          ]),
+          reviewScore: faker.helpers.arrayElement([
+            faker.number.float({
+              min: undefined,
+              max: undefined,
+              fractionDigits: 2,
+            }),
+            undefined,
+          ]),
+          cleanlinessScore: faker.helpers.arrayElement([
+            faker.number.float({
+              min: undefined,
+              max: undefined,
+              fractionDigits: 2,
+            }),
+            undefined,
+          ]),
+          reviewSummary: faker.helpers.arrayElement([
+            faker.string.alpha({ length: { min: 10, max: 20 } }),
+            undefined,
+          ]),
+          hotelId: faker.helpers.arrayElement([
+            faker.number.int({
+              min: undefined,
+              max: undefined,
+              multipleOf: undefined,
+            }),
+            undefined,
+          ]),
+          nearbyAttractions: faker.helpers.arrayElement([
+            Array.from(
+              { length: faker.number.int({ min: 4, max: 4 }) },
+              (_, i) => i + 1,
+            ).map(() => ({
+              name: faker.helpers.arrayElement([
+                faker.string.alpha({ length: { min: 10, max: 20 } }),
+                undefined,
+              ]),
+              type: faker.helpers.arrayElement([
+                faker.string.alpha({ length: { min: 10, max: 20 } }),
+                undefined,
+              ]),
+              latitude: faker.helpers.arrayElement([
+                faker.number.float({
+                  min: undefined,
+                  max: undefined,
+                  fractionDigits: 2,
+                }),
+                undefined,
+              ]),
+              longitude: faker.helpers.arrayElement([
+                faker.number.float({
+                  min: undefined,
+                  max: undefined,
+                  fractionDigits: 2,
+                }),
+                undefined,
+              ]),
+              distance: faker.helpers.arrayElement([
+                faker.string.alpha({ length: { min: 10, max: 20 } }),
+                undefined,
+              ]),
+              byFoot: faker.helpers.arrayElement([
+                {
+                  distance: faker.helpers.arrayElement([
+                    faker.string.alpha({ length: { min: 10, max: 20 } }),
+                    undefined,
+                  ]),
+                  time: faker.helpers.arrayElement([
+                    faker.string.alpha({ length: { min: 10, max: 20 } }),
+                    undefined,
+                  ]),
+                },
+                undefined,
+              ]),
+              byCar: faker.helpers.arrayElement([
+                {
+                  distance: faker.helpers.arrayElement([
+                    faker.string.alpha({ length: { min: 10, max: 20 } }),
+                    undefined,
+                  ]),
+                  time: faker.helpers.arrayElement([
+                    faker.string.alpha({ length: { min: 10, max: 20 } }),
+                    undefined,
+                  ]),
+                },
+                undefined,
+              ]),
+            })),
+            undefined,
+          ]),
+          nearbyTransportation: faker.helpers.arrayElement([
+            Array.from(
+              { length: faker.number.int({ min: 4, max: 4 }) },
+              (_, i) => i + 1,
+            ).map(() => ({
+              name: faker.helpers.arrayElement([
+                faker.string.alpha({ length: { min: 10, max: 20 } }),
+                undefined,
+              ]),
+              type: faker.helpers.arrayElement([
+                faker.string.alpha({ length: { min: 10, max: 20 } }),
+                undefined,
+              ]),
+              latitude: faker.helpers.arrayElement([
+                faker.number.float({
+                  min: undefined,
+                  max: undefined,
+                  fractionDigits: 2,
+                }),
+                undefined,
+              ]),
+              longitude: faker.helpers.arrayElement([
+                faker.number.float({
+                  min: undefined,
+                  max: undefined,
+                  fractionDigits: 2,
+                }),
+                undefined,
+              ]),
+              distance: faker.helpers.arrayElement([
+                faker.string.alpha({ length: { min: 10, max: 20 } }),
+                undefined,
+              ]),
+              byFoot: faker.helpers.arrayElement([
+                {
+                  distance: faker.helpers.arrayElement([
+                    faker.string.alpha({ length: { min: 10, max: 20 } }),
+                    undefined,
+                  ]),
+                  time: faker.helpers.arrayElement([
+                    faker.string.alpha({ length: { min: 10, max: 20 } }),
+                    undefined,
+                  ]),
+                },
+                undefined,
+              ]),
+              byCar: faker.helpers.arrayElement([
+                {
+                  distance: faker.helpers.arrayElement([
+                    faker.string.alpha({ length: { min: 10, max: 20 } }),
+                    undefined,
+                  ]),
+                  time: faker.helpers.arrayElement([
+                    faker.string.alpha({ length: { min: 10, max: 20 } }),
+                    undefined,
+                  ]),
+                },
+                undefined,
+              ]),
+            })),
+            undefined,
+          ]),
+          amenities: faker.helpers.arrayElement([
+            Array.from(
+              { length: faker.number.int({ min: 4, max: 4 }) },
+              (_, i) => i + 1,
+            ).map(() => ({
+              type: faker.helpers.arrayElement([
+                faker.string.alpha({ length: { min: 10, max: 20 } }),
+                undefined,
+              ]),
+              available: faker.helpers.arrayElement([
+                faker.datatype.boolean(),
+                undefined,
+              ]),
+              description: faker.helpers.arrayElement([
+                faker.string.alpha({ length: { min: 10, max: 20 } }),
+                undefined,
+              ]),
+            })),
+            undefined,
+          ]),
+          checkInTime: faker.helpers.arrayElement([
+            {
+              from: faker.helpers.arrayElement([
+                faker.string.alpha({ length: { min: 10, max: 20 } }),
+                undefined,
+              ]),
+              to: faker.helpers.arrayElement([
+                faker.string.alpha({ length: { min: 10, max: 20 } }),
+                undefined,
+              ]),
+            },
+            undefined,
+          ]),
+          checkOutTime: faker.helpers.arrayElement([
+            {
+              from: faker.helpers.arrayElement([
+                faker.string.alpha({ length: { min: 10, max: 20 } }),
+                undefined,
+              ]),
+              to: faker.helpers.arrayElement([
+                faker.string.alpha({ length: { min: 10, max: 20 } }),
+                undefined,
+              ]),
+            },
+            undefined,
+          ]),
+        })),
+        undefined,
+      ]),
+      shareCode: faker.helpers.arrayElement([
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
+        undefined,
+      ]),
+      factorsList: faker.helpers.arrayElement([
+        faker.helpers.arrayElements([
+          "REVIEW_SCORE",
+          "ATTRACTION",
+          "TRANSPORTATION",
+          "CLEANLINESS",
+          "AMENITY",
+          "CHECK_TIME",
+          "REVIEW_SUMMARY",
+          "MEMO",
+        ] as const),
+        undefined,
+      ]),
+      createdBy: faker.helpers.arrayElement([
+        faker.number.int({
+          min: undefined,
+          max: undefined,
+          multipleOf: undefined,
+        }),
+        undefined,
+      ]),
+      creatorName: faker.helpers.arrayElement([
+        faker.string.alpha({ length: { min: 10, max: 20 } }),
+        undefined,
+      ]),
+    },
+    undefined,
+  ]),
+  ...overrideResponse,
+});
+
+export const getGetComparisonTablesByTripBoardResponseMock = (
+  overrideResponse: Partial<StandardResponseComparisonTablePageResponse> = {},
+): StandardResponseComparisonTablePageResponse => ({
+  responseType: faker.helpers.arrayElement([
+    faker.helpers.arrayElement(["SUCCESS", "ERROR"] as const),
+    undefined,
+  ]),
+  result: faker.helpers.arrayElement([
+    {
+      comparisonTables: faker.helpers.arrayElement([
+        Array.from(
+          { length: faker.number.int({ min: 4, max: 4 }) },
+          (_, i) => i + 1,
+        ).map(() => ({
+          tableId: faker.helpers.arrayElement([
+            faker.number.int({
+              min: undefined,
+              max: undefined,
+              multipleOf: undefined,
+            }),
+            undefined,
+          ]),
+          tableName: faker.helpers.arrayElement([
+            faker.string.alpha({ length: { min: 10, max: 20 } }),
+            undefined,
+          ]),
+          accommodationCount: faker.helpers.arrayElement([
+            faker.number.int({
+              min: undefined,
+              max: undefined,
+              multipleOf: undefined,
+            }),
+            undefined,
+          ]),
+          accommodationNames: faker.helpers.arrayElement([
+            Array.from(
+              { length: faker.number.int({ min: 4, max: 4 }) },
+              (_, i) => i + 1,
+            ).map(() => faker.string.alpha({ length: { min: 10, max: 20 } })),
+            undefined,
+          ]),
+          lastModifiedAt: faker.helpers.arrayElement([
+            new Date(`${faker.date.past().toISOString().split(".")[0]}Z`),
+            undefined,
+          ]),
+          shareCode: faker.helpers.arrayElement([
+            faker.string.alpha({ length: { min: 10, max: 20 } }),
+            undefined,
+          ]),
+        })),
+        undefined,
+      ]),
+      hasNext: faker.helpers.arrayElement([
+        faker.datatype.boolean(),
         undefined,
       ]),
     },
@@ -2739,6 +3179,56 @@ export const getGetKakaoAuthorizeUrlMockHandler = (
   });
 };
 
+export const getGetComparisonTableByShareCodeMockHandler = (
+  overrideResponse?:
+    | StandardResponseComparisonTableResponse
+    | ((
+        info: Parameters<Parameters<typeof http.get>[1]>[0],
+      ) =>
+        | Promise<StandardResponseComparisonTableResponse>
+        | StandardResponseComparisonTableResponse),
+) => {
+  return http.get("*/api/comparison/:tableId/shared", async (info) => {
+    await delay(500);
+
+    return new HttpResponse(
+      JSON.stringify(
+        overrideResponse !== undefined
+          ? typeof overrideResponse === "function"
+            ? await overrideResponse(info)
+            : overrideResponse
+          : getGetComparisonTableByShareCodeResponseMock(),
+      ),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+};
+
+export const getGetComparisonTablesByTripBoardMockHandler = (
+  overrideResponse?:
+    | StandardResponseComparisonTablePageResponse
+    | ((
+        info: Parameters<Parameters<typeof http.get>[1]>[0],
+      ) =>
+        | Promise<StandardResponseComparisonTablePageResponse>
+        | StandardResponseComparisonTablePageResponse),
+) => {
+  return http.get("*/api/comparison/trip-board/:tripBoardId", async (info) => {
+    await delay(500);
+
+    return new HttpResponse(
+      JSON.stringify(
+        overrideResponse !== undefined
+          ? typeof overrideResponse === "function"
+            ? await overrideResponse(info)
+            : overrideResponse
+          : getGetComparisonTablesByTripBoardResponseMock(),
+      ),
+      { status: 200, headers: { "Content-Type": "application/json" } },
+    );
+  });
+};
+
 export const getGetComparisonFactorListMockHandler = (
   overrideResponse?:
     | StandardResponseComparisonFactorList
@@ -2910,6 +3400,8 @@ export const getYapp26Web2Mock = () => [
   getGetInvitationCodeMockHandler(),
   getGetTripBoardsMockHandler(),
   getGetKakaoAuthorizeUrlMockHandler(),
+  getGetComparisonTableByShareCodeMockHandler(),
+  getGetComparisonTablesByTripBoardMockHandler(),
   getGetComparisonFactorListMockHandler(),
   getGetAmenityFactorListMockHandler(),
   getGetAccommodationByIdMockHandler(),

--- a/packages/api/src/index.schemas.ts
+++ b/packages/api/src/index.schemas.ts
@@ -511,8 +511,10 @@ export interface ComparisonTableResponse {
   tableId?: number;
   tableName?: string;
   accommodationResponsesList?: AccommodationResponse[];
+  shareCode?: string;
   factorsList?: ComparisonTableResponseFactorsListItem[];
   createdBy?: number;
+  creatorName?: string;
 }
 
 /**
@@ -678,6 +680,45 @@ export interface StandardResponseAuthorizeUrlResponse {
   responseType?: StandardResponseAuthorizeUrlResponseResponseType;
   /** 응답 결과 데이터 */
   result?: AuthorizeUrlResponse;
+}
+
+export interface ComparisonTablePageResponse {
+  comparisonTables?: ComparisonTableSummaryResponse[];
+  hasNext?: boolean;
+}
+
+/**
+ * 비교표 목록 조회 응답
+ */
+export interface ComparisonTableSummaryResponse {
+  /** 비교표 ID */
+  tableId?: number;
+  /** 비교표 이름 */
+  tableName?: string;
+  /** 포함된 숙소 개수 */
+  accommodationCount?: number;
+  /** 포함된 숙소 이름들 */
+  accommodationNames?: string[];
+  /** 최근 수정일 (UTC) */
+  lastModifiedAt?: Date;
+  /** 공유 코드 */
+  readonly shareCode?: string;
+}
+
+/**
+ * 응답 유형
+ */
+export type StandardResponseComparisonTablePageResponseResponseType =
+  | "SUCCESS"
+  | "ERROR";
+/**
+ * API 응답의 표준 형식을 정의하는 클래스
+ */
+export interface StandardResponseComparisonTablePageResponse {
+  /** 응답 유형 */
+  responseType?: StandardResponseComparisonTablePageResponseResponseType;
+  /** 응답 결과 데이터 */
+  result?: ComparisonTablePageResponse;
 }
 
 export type ComparisonFactorListFactorsItem =
@@ -878,6 +919,24 @@ export type GetTripBoardsParams = {
 
 export type GetKakaoAuthorizeUrlParams = {
   baseUrl: string;
+};
+
+export type GetComparisonTableByShareCodeParams = {
+  /**
+   * 비교표 공유 코드
+   */
+  shareCode: string;
+};
+
+export type GetComparisonTablesByTripBoardParams = {
+  /**
+   * 페이지 번호 (0부터 시작)
+   */
+  page: number;
+  /**
+   * 페이지 크기
+   */
+  size: number;
 };
 
 export type GetAccommodationByTripBoardIdAndUserIdParams = {

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -40,6 +40,8 @@ import type {
   ExchangeKakaoTokenParams,
   GetAccommodationByTripBoardIdAndUserIdParams,
   GetAccommodationCountByTripBoardIdParams,
+  GetComparisonTableByShareCodeParams,
+  GetComparisonTablesByTripBoardParams,
   GetKakaoAuthorizeUrlParams,
   GetTripBoardsParams,
   RefreshTokenRequest,
@@ -53,6 +55,7 @@ import type {
   StandardResponseBoolean,
   StandardResponseComparisonFactorList,
   StandardResponseComparisonTableDeleteResponse,
+  StandardResponseComparisonTablePageResponse,
   StandardResponseComparisonTableResponse,
   StandardResponseCreateComparisonTableResponse,
   StandardResponseInvitationCodeResponse,
@@ -627,7 +630,7 @@ export const useDeleteTripBoard = <TError = unknown, TContext = unknown>(
 };
 
 /**
- * 비교표 메타 데이터와 포함된 숙소 정보 리스트를 조회합니다. (Authorization 헤더에 Bearer 토큰 필요)
+ * 비교표 메타 데이터와 포함된 숙소 정보 리스트를 조회합니다. JWT 인증이 필요하며, 비교표 생성자 또는 여행보드 참여자만 접근 가능합니다.
  * @summary 비교표 조회
  */
 export type getComparisonTableResponse200 = {
@@ -3898,6 +3901,808 @@ export function useGetKakaoAuthorizeUrlSuspense<
   queryKey: DataTag<QueryKey, TData, TError>;
 } {
   const queryOptions = getGetKakaoAuthorizeUrlSuspenseQueryOptions(
+    params,
+    options,
+  );
+
+  const query = useSuspenseQuery(
+    queryOptions,
+    queryClient,
+  ) as UseSuspenseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  query.queryKey = queryOptions.queryKey;
+
+  return query;
+}
+
+/**
+ * shareCode를 사용하여 인증 없이 비교표를 조회합니다. 유효한 shareCode가 필요합니다.
+ * @summary shareCode를 통한 비교표 조회
+ */
+export type getComparisonTableByShareCodeResponse200 = {
+  data: StandardResponseComparisonTableResponse;
+  status: 200;
+};
+
+export type getComparisonTableByShareCodeResponseComposite =
+  getComparisonTableByShareCodeResponse200;
+
+export type getComparisonTableByShareCodeResponse =
+  getComparisonTableByShareCodeResponseComposite & {
+    headers: Headers;
+  };
+
+export const getGetComparisonTableByShareCodeUrl = (
+  tableId: number,
+  params: GetComparisonTableByShareCodeParams,
+) => {
+  const normalizedParams = new URLSearchParams();
+
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value !== undefined) {
+      normalizedParams.append(key, value === null ? "null" : value.toString());
+    }
+  });
+
+  const stringifiedParams = normalizedParams.toString();
+
+  return stringifiedParams.length > 0
+    ? `https://api.ssok.info/api/comparison/${tableId}/shared?${stringifiedParams}`
+    : `https://api.ssok.info/api/comparison/${tableId}/shared`;
+};
+
+export const getComparisonTableByShareCode = async (
+  tableId: number,
+  params: GetComparisonTableByShareCodeParams,
+  options?: RequestInit,
+): Promise<getComparisonTableByShareCodeResponse> => {
+  return http<getComparisonTableByShareCodeResponse>(
+    getGetComparisonTableByShareCodeUrl(tableId, params),
+    {
+      ...options,
+      method: "GET",
+    },
+  );
+};
+
+export const getGetComparisonTableByShareCodeQueryKey = (
+  tableId?: number,
+  params?: GetComparisonTableByShareCodeParams,
+) => {
+  return [
+    `https://api.ssok.info/api/comparison/${tableId}/shared`,
+    ...(params ? [params] : []),
+  ] as const;
+};
+
+export const getGetComparisonTableByShareCodeQueryOptions = <
+  TData = Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+  TError = unknown,
+>(
+  tableId: number,
+  params: GetComparisonTableByShareCodeParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ??
+    getGetComparisonTableByShareCodeQueryKey(tableId, params);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof getComparisonTableByShareCode>>
+  > = ({ signal }) =>
+    getComparisonTableByShareCode(tableId, params, {
+      signal,
+      ...requestOptions,
+    });
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: !!tableId,
+    ...queryOptions,
+  } as UseQueryOptions<
+    Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetComparisonTableByShareCodeQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getComparisonTableByShareCode>>
+>;
+export type GetComparisonTableByShareCodeQueryError = unknown;
+
+export function useGetComparisonTableByShareCode<
+  TData = Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+  TError = unknown,
+>(
+  tableId: number,
+  params: GetComparisonTableByShareCodeParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+          TError,
+          Awaited<ReturnType<typeof getComparisonTableByShareCode>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetComparisonTableByShareCode<
+  TData = Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+  TError = unknown,
+>(
+  tableId: number,
+  params: GetComparisonTableByShareCodeParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+          TError,
+          Awaited<ReturnType<typeof getComparisonTableByShareCode>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetComparisonTableByShareCode<
+  TData = Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+  TError = unknown,
+>(
+  tableId: number,
+  params: GetComparisonTableByShareCodeParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary shareCode를 통한 비교표 조회
+ */
+
+export function useGetComparisonTableByShareCode<
+  TData = Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+  TError = unknown,
+>(
+  tableId: number,
+  params: GetComparisonTableByShareCodeParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetComparisonTableByShareCodeQueryOptions(
+    tableId,
+    params,
+    options,
+  );
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey;
+
+  return query;
+}
+
+/**
+ * @summary shareCode를 통한 비교표 조회
+ */
+export const prefetchGetComparisonTableByShareCodeQuery = async <
+  TData = Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+  TError = unknown,
+>(
+  queryClient: QueryClient,
+  tableId: number,
+  params: GetComparisonTableByShareCodeParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+): Promise<QueryClient> => {
+  const queryOptions = getGetComparisonTableByShareCodeQueryOptions(
+    tableId,
+    params,
+    options,
+  );
+
+  await queryClient.prefetchQuery(queryOptions);
+
+  return queryClient;
+};
+
+export const getGetComparisonTableByShareCodeSuspenseQueryOptions = <
+  TData = Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+  TError = unknown,
+>(
+  tableId: number,
+  params: GetComparisonTableByShareCodeParams,
+  options?: {
+    query?: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ??
+    getGetComparisonTableByShareCodeQueryKey(tableId, params);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof getComparisonTableByShareCode>>
+  > = ({ signal }) =>
+    getComparisonTableByShareCode(tableId, params, {
+      signal,
+      ...requestOptions,
+    });
+
+  return { queryKey, queryFn, ...queryOptions } as UseSuspenseQueryOptions<
+    Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetComparisonTableByShareCodeSuspenseQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getComparisonTableByShareCode>>
+>;
+export type GetComparisonTableByShareCodeSuspenseQueryError = unknown;
+
+export function useGetComparisonTableByShareCodeSuspense<
+  TData = Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+  TError = unknown,
+>(
+  tableId: number,
+  params: GetComparisonTableByShareCodeParams,
+  options: {
+    query: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseSuspenseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetComparisonTableByShareCodeSuspense<
+  TData = Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+  TError = unknown,
+>(
+  tableId: number,
+  params: GetComparisonTableByShareCodeParams,
+  options?: {
+    query?: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseSuspenseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetComparisonTableByShareCodeSuspense<
+  TData = Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+  TError = unknown,
+>(
+  tableId: number,
+  params: GetComparisonTableByShareCodeParams,
+  options?: {
+    query?: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseSuspenseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary shareCode를 통한 비교표 조회
+ */
+
+export function useGetComparisonTableByShareCodeSuspense<
+  TData = Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+  TError = unknown,
+>(
+  tableId: number,
+  params: GetComparisonTableByShareCodeParams,
+  options?: {
+    query?: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getComparisonTableByShareCode>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseSuspenseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetComparisonTableByShareCodeSuspenseQueryOptions(
+    tableId,
+    params,
+    options,
+  );
+
+  const query = useSuspenseQuery(
+    queryOptions,
+    queryClient,
+  ) as UseSuspenseQueryResult<TData, TError> & {
+    queryKey: DataTag<QueryKey, TData, TError>;
+  };
+
+  query.queryKey = queryOptions.queryKey;
+
+  return query;
+}
+
+/**
+ * 특정 여행보드에 생성된 모든 비교표의 리스트를 무한스크롤 페이지네이션으로 조회합니다. 각 비교표의 기본 정보와 포함된 숙소 정보를 제공합니다.
+ * @summary 여행보드의 비교표 리스트 조회
+ */
+export type getComparisonTablesByTripBoardResponse200 = {
+  data: StandardResponseComparisonTablePageResponse;
+  status: 200;
+};
+
+export type getComparisonTablesByTripBoardResponseComposite =
+  getComparisonTablesByTripBoardResponse200;
+
+export type getComparisonTablesByTripBoardResponse =
+  getComparisonTablesByTripBoardResponseComposite & {
+    headers: Headers;
+  };
+
+export const getGetComparisonTablesByTripBoardUrl = (
+  tripBoardId: number,
+  params: GetComparisonTablesByTripBoardParams,
+) => {
+  const normalizedParams = new URLSearchParams();
+
+  Object.entries(params || {}).forEach(([key, value]) => {
+    if (value !== undefined) {
+      normalizedParams.append(key, value === null ? "null" : value.toString());
+    }
+  });
+
+  const stringifiedParams = normalizedParams.toString();
+
+  return stringifiedParams.length > 0
+    ? `https://api.ssok.info/api/comparison/trip-board/${tripBoardId}?${stringifiedParams}`
+    : `https://api.ssok.info/api/comparison/trip-board/${tripBoardId}`;
+};
+
+export const getComparisonTablesByTripBoard = async (
+  tripBoardId: number,
+  params: GetComparisonTablesByTripBoardParams,
+  options?: RequestInit,
+): Promise<getComparisonTablesByTripBoardResponse> => {
+  return http<getComparisonTablesByTripBoardResponse>(
+    getGetComparisonTablesByTripBoardUrl(tripBoardId, params),
+    {
+      ...options,
+      method: "GET",
+    },
+  );
+};
+
+export const getGetComparisonTablesByTripBoardQueryKey = (
+  tripBoardId?: number,
+  params?: GetComparisonTablesByTripBoardParams,
+) => {
+  return [
+    `https://api.ssok.info/api/comparison/trip-board/${tripBoardId}`,
+    ...(params ? [params] : []),
+  ] as const;
+};
+
+export const getGetComparisonTablesByTripBoardQueryOptions = <
+  TData = Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+  TError = unknown,
+>(
+  tripBoardId: number,
+  params: GetComparisonTablesByTripBoardParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ??
+    getGetComparisonTablesByTripBoardQueryKey(tripBoardId, params);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>
+  > = ({ signal }) =>
+    getComparisonTablesByTripBoard(tripBoardId, params, {
+      signal,
+      ...requestOptions,
+    });
+
+  return {
+    queryKey,
+    queryFn,
+    enabled: !!tripBoardId,
+    ...queryOptions,
+  } as UseQueryOptions<
+    Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetComparisonTablesByTripBoardQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>
+>;
+export type GetComparisonTablesByTripBoardQueryError = unknown;
+
+export function useGetComparisonTablesByTripBoard<
+  TData = Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+  TError = unknown,
+>(
+  tripBoardId: number,
+  params: GetComparisonTablesByTripBoardParams,
+  options: {
+    query: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        DefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+          TError,
+          Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): DefinedUseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetComparisonTablesByTripBoard<
+  TData = Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+  TError = unknown,
+>(
+  tripBoardId: number,
+  params: GetComparisonTablesByTripBoardParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+        TError,
+        TData
+      >
+    > &
+      Pick<
+        UndefinedInitialDataOptions<
+          Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+          TError,
+          Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>
+        >,
+        "initialData"
+      >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetComparisonTablesByTripBoard<
+  TData = Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+  TError = unknown,
+>(
+  tripBoardId: number,
+  params: GetComparisonTablesByTripBoardParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary 여행보드의 비교표 리스트 조회
+ */
+
+export function useGetComparisonTablesByTripBoard<
+  TData = Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+  TError = unknown,
+>(
+  tripBoardId: number,
+  params: GetComparisonTablesByTripBoardParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetComparisonTablesByTripBoardQueryOptions(
+    tripBoardId,
+    params,
+    options,
+  );
+
+  const query = useQuery(queryOptions, queryClient) as UseQueryResult<
+    TData,
+    TError
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+
+  query.queryKey = queryOptions.queryKey;
+
+  return query;
+}
+
+/**
+ * @summary 여행보드의 비교표 리스트 조회
+ */
+export const prefetchGetComparisonTablesByTripBoardQuery = async <
+  TData = Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+  TError = unknown,
+>(
+  queryClient: QueryClient,
+  tripBoardId: number,
+  params: GetComparisonTablesByTripBoardParams,
+  options?: {
+    query?: Partial<
+      UseQueryOptions<
+        Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+): Promise<QueryClient> => {
+  const queryOptions = getGetComparisonTablesByTripBoardQueryOptions(
+    tripBoardId,
+    params,
+    options,
+  );
+
+  await queryClient.prefetchQuery(queryOptions);
+
+  return queryClient;
+};
+
+export const getGetComparisonTablesByTripBoardSuspenseQueryOptions = <
+  TData = Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+  TError = unknown,
+>(
+  tripBoardId: number,
+  params: GetComparisonTablesByTripBoardParams,
+  options?: {
+    query?: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+) => {
+  const { query: queryOptions, request: requestOptions } = options ?? {};
+
+  const queryKey =
+    queryOptions?.queryKey ??
+    getGetComparisonTablesByTripBoardQueryKey(tripBoardId, params);
+
+  const queryFn: QueryFunction<
+    Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>
+  > = ({ signal }) =>
+    getComparisonTablesByTripBoard(tripBoardId, params, {
+      signal,
+      ...requestOptions,
+    });
+
+  return { queryKey, queryFn, ...queryOptions } as UseSuspenseQueryOptions<
+    Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+    TError,
+    TData
+  > & { queryKey: DataTag<QueryKey, TData, TError> };
+};
+
+export type GetComparisonTablesByTripBoardSuspenseQueryResult = NonNullable<
+  Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>
+>;
+export type GetComparisonTablesByTripBoardSuspenseQueryError = unknown;
+
+export function useGetComparisonTablesByTripBoardSuspense<
+  TData = Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+  TError = unknown,
+>(
+  tripBoardId: number,
+  params: GetComparisonTablesByTripBoardParams,
+  options: {
+    query: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseSuspenseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetComparisonTablesByTripBoardSuspense<
+  TData = Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+  TError = unknown,
+>(
+  tripBoardId: number,
+  params: GetComparisonTablesByTripBoardParams,
+  options?: {
+    query?: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseSuspenseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+export function useGetComparisonTablesByTripBoardSuspense<
+  TData = Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+  TError = unknown,
+>(
+  tripBoardId: number,
+  params: GetComparisonTablesByTripBoardParams,
+  options?: {
+    query?: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseSuspenseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+};
+/**
+ * @summary 여행보드의 비교표 리스트 조회
+ */
+
+export function useGetComparisonTablesByTripBoardSuspense<
+  TData = Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+  TError = unknown,
+>(
+  tripBoardId: number,
+  params: GetComparisonTablesByTripBoardParams,
+  options?: {
+    query?: Partial<
+      UseSuspenseQueryOptions<
+        Awaited<ReturnType<typeof getComparisonTablesByTripBoard>>,
+        TError,
+        TData
+      >
+    >;
+    request?: SecondParameter<typeof http>;
+  },
+  queryClient?: QueryClient,
+): UseSuspenseQueryResult<TData, TError> & {
+  queryKey: DataTag<QueryKey, TData, TError>;
+} {
+  const queryOptions = getGetComparisonTablesByTripBoardSuspenseQueryOptions(
+    tripBoardId,
     params,
     options,
   );


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- orval open API 를 최신화하였습니다

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 공유 코드로 비교 테이블을 로그인 없이 조회할 수 있습니다.
  * 여행 보드별 비교 테이블을 무한 스크롤 방식으로 목록 조회할 수 있습니다.
  * 비교 테이블 응답에 생성자 이름과 공유 코드가 포함되어 표시 정확도가 높아졌습니다.
  * 페이지네이션 정보(다음 페이지 여부)로 탐색이 더 쉬워집니다.
* 문서
  * 인증 범위와 접근 방식 관련 API 설명을 업데이트했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->