### PR TITLE
[Y26W2-345] feat(web): 비교표 삭제 모달 및 api 연동

### DIFF
--- a/apps/web/src/domains/compare/components/compare-tile/index.tsx
+++ b/apps/web/src/domains/compare/components/compare-tile/index.tsx
@@ -11,10 +11,10 @@ import useSession from "@/shared/hooks/use-session";
 import { formatDate } from "@/shared/utils/date";
 import CompareShareModal from "../compare-share-modal";
 
-type CompareTileProps = {
+interface CompareTileProps {
   table: ComparisonTableSummaryResponse;
   tripBoardId: number;
-};
+}
 
 const CompareTile = ({ table, tripBoardId }: CompareTileProps) => {
   const { toast } = useToast();

--- a/apps/web/src/domains/compare/components/compare-tile/index.tsx
+++ b/apps/web/src/domains/compare/components/compare-tile/index.tsx
@@ -1,0 +1,101 @@
+import {
+  getGetComparisonTablesByTripBoardQueryKey,
+  useDeleteComparisonTable,
+} from "@ssok/api";
+import type { ComparisonTableSummaryResponse } from "@ssok/api/schemas";
+import { Confirm, Tile, useToast, useToggle } from "@ssok/ui";
+import { useQueryClient } from "@tanstack/react-query";
+import Link from "next/link";
+import { useState } from "react";
+import useSession from "@/shared/hooks/use-session";
+import { formatDate } from "@/shared/utils/date";
+import CompareShareModal from "../compare-share-modal";
+
+type CompareTileProps = {
+  table: ComparisonTableSummaryResponse;
+  tripBoardId: number;
+};
+
+const CompareTile = ({ table, tripBoardId }: CompareTileProps) => {
+  const { toast } = useToast();
+  const [shareCode, setShareCode] = useState<string | undefined>();
+  const shareModal = useToggle();
+  const deleteModal = useToggle();
+
+  const { accessToken } = useSession({ required: true });
+  const queryClient = useQueryClient();
+  const { mutate: deleteTable, isPending: isDeleting } =
+    useDeleteComparisonTable({
+      mutation: {
+        onSuccess: () => {
+          deleteModal.deactivate();
+          queryClient.invalidateQueries({
+            queryKey: getGetComparisonTablesByTripBoardQueryKey(tripBoardId),
+          });
+          toast.success("여행이 삭제되었어요");
+        },
+        onError: (error) => {
+          console.error("보드 삭제 실패:", error);
+        },
+      },
+      request: { headers: { Authorization: `Bearer ${accessToken}` } },
+    });
+
+  const onClickShare = (code: string) => {
+    setShareCode(code);
+    shareModal.activate();
+  };
+
+  const handleCancel = () => {
+    if (!isDeleting) {
+      deleteModal.deactivate();
+    }
+  };
+
+  const onClickDeleteConfirm = () => {
+    if (!table.tableId) {
+      return;
+    }
+    deleteTable({ tableId: table.tableId });
+  };
+
+  return (
+    <>
+      <Link
+        key={table.tableId}
+        href={`/boards/${tripBoardId}/compares/${table.tableId}`}
+      >
+        <Tile
+          key={table.tableId}
+          data={{
+            tableName: table.tableName ?? "",
+            accommodationCount: table.accommodationCount ?? 0,
+            accommodationNames: table.accommodationNames ?? [],
+            lastModifiedAt: formatDate(table.lastModifiedAt ?? new Date(), {
+              format: "YY.MM.DD",
+            }),
+          }}
+          onDeleteClick={() => deleteModal.activate()}
+          onEditClick={() => {}}
+          onShareClick={() => onClickShare(table.shareCode ?? "")}
+        />
+      </Link>
+      <Confirm
+        active={deleteModal.active}
+        title="표를 삭제할까요?"
+        description={`정말로 '${table.tableName || "비교"}' 표를 삭제하시겠어요? 한 번 삭제하면 다시 복구할 수 없어요.`}
+        cancelText="닫기"
+        confirmText="삭제하기"
+        onCancel={isDeleting ? undefined : handleCancel}
+        onConfirm={isDeleting ? undefined : onClickDeleteConfirm}
+      />
+      <CompareShareModal
+        shareCode={shareCode}
+        active={shareModal.active}
+        deactivate={shareModal.deactivate}
+      />
+    </>
+  );
+};
+
+export default CompareTile;

--- a/apps/web/src/domains/compare/views/compare-list-view/index.tsx
+++ b/apps/web/src/domains/compare/views/compare-list-view/index.tsx
@@ -4,13 +4,11 @@ import {
   useGetComparisonTablesByTripBoardInfinite,
   useGetTripBoardDetail,
 } from "@ssok/api";
-import { cn, LoadingIndicator, Tile, useToggle } from "@ssok/ui";
-import Link from "next/link";
-import { useEffect, useState } from "react";
+import { cn, LoadingIndicator } from "@ssok/ui";
+import { useEffect } from "react";
 import HeaderSection from "@/domains/list/components/header-section";
 import useSession from "@/shared/hooks/use-session";
-import { formatDate } from "@/shared/utils/date";
-import CompareShareModal from "../../components/compare-share-modal";
+import CompareTile from "../../components/compare-tile";
 
 interface CompareListViewProps {
   tripBoardId: number;
@@ -18,12 +16,6 @@ interface CompareListViewProps {
 
 const CompareListView = ({ tripBoardId }: CompareListViewProps) => {
   const { accessToken } = useSession({ required: true });
-  const [shareCode, setShareCode] = useState<string | undefined>();
-  const {
-    activate: openShareModal,
-    deactivate: closeShareModal,
-    active: isShareModalOpen,
-  } = useToggle();
 
   const {
     data: { pages } = {},
@@ -61,11 +53,6 @@ const CompareListView = ({ tripBoardId }: CompareListViewProps) => {
     }
   }, [accessToken, hasNextPage, isFetching, fetchNextPage]);
 
-  const onClickShare = (code: string) => {
-    setShareCode(code);
-    openShareModal();
-  };
-
   return (
     <section className="flex h-screen w-full flex-col gap-[1.6rem] bg-neutral-98 p-[2.4rem] [&+div]:w-0">
       <HeaderSection {...tripBoardDetail?.data.result} />
@@ -79,28 +66,9 @@ const CompareListView = ({ tripBoardId }: CompareListViewProps) => {
         </h1>
         <ul className="grid grid-cols-2 gap-[1.6rem] p-[2.4rem]">
           {allTripBoards.map((table) => (
-            <Link
-              key={table.tableId}
-              href={`/boards/${tripBoardId}/compares/${table.tableId}`}
-            >
-              <Tile
-                key={table.tableId}
-                data={{
-                  tableName: table.tableName ?? "",
-                  accommodationCount: table.accommodationCount ?? 0,
-                  accommodationNames: table.accommodationNames ?? [],
-                  lastModifiedAt: formatDate(
-                    table.lastModifiedAt ?? new Date(),
-                    {
-                      format: "YY.MM.DD",
-                    },
-                  ),
-                }}
-                onDeleteClick={() => {}}
-                onEditClick={() => {}}
-                onShareClick={() => onClickShare(table.shareCode ?? "")}
-              />
-            </Link>
+            <li key={table.tableId}>
+              <CompareTile table={table} tripBoardId={tripBoardId} />
+            </li>
           ))}
           {/* TODO: empty list 반영 */}
           {allTripBoards.length === 0 && (
@@ -110,11 +78,6 @@ const CompareListView = ({ tripBoardId }: CompareListViewProps) => {
           )}
         </ul>
       </div>
-      <CompareShareModal
-        shareCode={shareCode}
-        active={isShareModalOpen}
-        deactivate={closeShareModal}
-      />
       <LoadingIndicator active={isFetching || isTripBoardLoading} />
     </section>
   );


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 비교표 삭제 모달 연동 및 api 연결했습니다

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

https://github.com/user-attachments/assets/cc089755-6b1a-4d00-88f7-cc8376f50d9e

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 비교표를 개별 클릭 가능한 타일로 추가: 이름, 숙소 수/목록, 마지막 수정일을 표시하고 상세 페이지로 이동
  - 타일에서 공유 및 삭제 동작 지원: 공유 모달 및 삭제 확인 모달 포함

- Refactor
  - 비교표 목록을 간소화하여 각 항목을 단일 타일로 렌더링
  - 날짜 포맷 및 공유/삭제 흐름을 타일로 일원화
  - 항목이 없을 때 빈 상태 메시지 표시: “생성된 비교표가 없습니다.”
<!-- end of auto-generated comment: release notes by coderabbit.ai -->