### PR TITLE
[Y26W2-344] feat(web): 비교표 수정 모달 구현 및 api 연결 

### DIFF
--- a/apps/web/src/domains/compare/components/compare-edit-modal/index.tsx
+++ b/apps/web/src/domains/compare/components/compare-edit-modal/index.tsx
@@ -1,0 +1,49 @@
+import { Button, Popup, TextField } from "@ssok/ui";
+import { useForm } from "react-hook-form";
+
+interface CompareEditModalProps {
+  active: boolean;
+  initialName: string;
+  onClose: () => void;
+  onConfirm: (data: { tableName: string }) => void;
+}
+
+const CompareEditModal = ({
+  active,
+  initialName,
+  onClose,
+  onConfirm,
+}: CompareEditModalProps) => {
+  const { register, handleSubmit } = useForm<{ tableName: string }>({
+    defaultValues: { tableName: initialName },
+  });
+
+  return (
+    <Popup title="표 수정하기" active={active} onClose={onClose}>
+      <form className="w-[59.9rem]" onSubmit={handleSubmit(onConfirm)}>
+        <div className="flex flex-col gap-[0.8rem] px-[2.4rem] py-[2rem]">
+          <p className="text-heading2-semi18 text-neutral-30">
+            이 표를 어떻게 부를까요?
+          </p>
+          <TextField
+            maxLength={20}
+            placeholder="입력하지 않으면 기존 이름으로 저장돼요."
+            {...register("tableName")}
+          />
+        </div>
+        <div className="w-full p-[2.4rem]">
+          <Button
+            type="submit"
+            variant="primary"
+            size="lg"
+            className="flex w-full justify-center"
+          >
+            수정하기
+          </Button>
+        </div>
+      </form>
+    </Popup>
+  );
+};
+
+export default CompareEditModal;

--- a/apps/web/src/domains/compare/components/compare-tile/index.tsx
+++ b/apps/web/src/domains/compare/components/compare-tile/index.tsx
@@ -115,7 +115,6 @@ const CompareTile = ({ table, tripBoardId }: CompareTileProps) => {
             ?.accommodationResponsesList as UpdateAccommodationRequest[]) ||
             []),
         ],
-        factorList: comparisonTable?.data.result?.factorsList || [],
         ...comparisonTable?.data.result,
         tableName: newTableName,
         accommodationIdList: accommodationIds,

--- a/apps/web/src/domains/compare/components/compare-tile/index.tsx
+++ b/apps/web/src/domains/compare/components/compare-tile/index.tsx
@@ -1,12 +1,28 @@
 import {
+  getGetComparisonTableQueryKey,
   getGetComparisonTablesByTripBoardQueryKey,
   useDeleteComparisonTable,
+  useGetComparisonTable,
+  useUpdateComparisonTable,
 } from "@ssok/api";
-import type { ComparisonTableSummaryResponse } from "@ssok/api/schemas";
-import { Confirm, Tile, useToast, useToggle } from "@ssok/ui";
+import type {
+  ComparisonTableSummaryResponse,
+  UpdateAccommodationRequest,
+} from "@ssok/api/schemas";
+import {
+  Button,
+  Confirm,
+  LoadingIndicator,
+  Popup,
+  TextField,
+  Tile,
+  useToast,
+  useToggle,
+} from "@ssok/ui";
 import { useQueryClient } from "@tanstack/react-query";
 import Link from "next/link";
 import { useState } from "react";
+import { useForm } from "react-hook-form";
 import useSession from "@/shared/hooks/use-session";
 import { formatDate } from "@/shared/utils/date";
 import CompareShareModal from "../compare-share-modal";
@@ -21,9 +37,21 @@ const CompareTile = ({ table, tripBoardId }: CompareTileProps) => {
   const [shareCode, setShareCode] = useState<string | undefined>();
   const shareModal = useToggle();
   const deleteModal = useToggle();
+  const editModal = useToggle();
 
   const { accessToken } = useSession({ required: true });
   const queryClient = useQueryClient();
+  const { data: comparisonTable, isLoading: isMetaDataLoading } =
+    useGetComparisonTable(table.tableId || 0, {
+      query: {
+        enabled:
+          !!accessToken ||
+          !!queryClient.getQueryData(
+            getGetComparisonTableQueryKey(table.tableId),
+          ),
+      },
+      request: { headers: { Authorization: `Bearer ${accessToken}` } },
+    });
   const { mutate: deleteTable, isPending: isDeleting } =
     useDeleteComparisonTable({
       mutation: {
@@ -40,6 +68,28 @@ const CompareTile = ({ table, tripBoardId }: CompareTileProps) => {
       },
       request: { headers: { Authorization: `Bearer ${accessToken}` } },
     });
+
+  const { mutate: updateTable } = useUpdateComparisonTable({
+    mutation: {
+      onSuccess: () => {
+        editModal.deactivate();
+        queryClient.invalidateQueries({
+          queryKey: getGetComparisonTablesByTripBoardQueryKey(tripBoardId),
+        });
+        toast.success("표가 수정되었어요");
+      },
+      onError: (error) => {
+        console.error("표 수정 실패:", error);
+      },
+    },
+    request: { headers: { Authorization: `Bearer ${accessToken}` } },
+  });
+
+  const { register, handleSubmit } = useForm<{ tableName: string }>({
+    defaultValues: {
+      tableName: table.tableName,
+    },
+  });
 
   const onClickShare = (code: string) => {
     setShareCode(code);
@@ -59,6 +109,28 @@ const CompareTile = ({ table, tripBoardId }: CompareTileProps) => {
     deleteTable({ tableId: table.tableId });
   };
 
+  const onClickEditConfirm = (data: { tableName: string }) => {
+    if (!table.tableId) return;
+
+    let newTableName = data.tableName.trim();
+
+    if (newTableName === "") newTableName = table.tableName || "비교표";
+
+    updateTable({
+      tableId: table.tableId,
+      data: {
+        tripBoardId: tripBoardId,
+        accommodationRequestList: [
+          ...((comparisonTable?.data.result
+            ?.accommodationResponsesList as UpdateAccommodationRequest[]) ||
+            []),
+        ],
+        ...comparisonTable?.data.result,
+        tableName: newTableName,
+      },
+    });
+  };
+
   return (
     <>
       <Link
@@ -76,7 +148,7 @@ const CompareTile = ({ table, tripBoardId }: CompareTileProps) => {
             }),
           }}
           onDeleteClick={() => deleteModal.activate()}
-          onEditClick={() => {}}
+          onEditClick={() => editModal.activate()}
           onShareClick={() => onClickShare(table.shareCode ?? "")}
         />
       </Link>
@@ -89,11 +161,43 @@ const CompareTile = ({ table, tripBoardId }: CompareTileProps) => {
         onCancel={isDeleting ? undefined : handleCancel}
         onConfirm={isDeleting ? undefined : onClickDeleteConfirm}
       />
+      <Popup
+        title="표 수정하기"
+        active={editModal.active}
+        onClose={editModal.deactivate}
+      >
+        <form
+          className="w-[59.9rem]"
+          onSubmit={handleSubmit(onClickEditConfirm)}
+        >
+          <div className="flex flex-col gap-[0.8rem] px-[2.4rem] py-[2rem]">
+            <p className="text-heading2-semi18 text-neutral-30">
+              이 표를 어떻게 부를까요?
+            </p>
+            <TextField
+              maxLength={20}
+              placeholder="입력하지 않으면 기존 이름으로 저장돼요."
+              {...register("tableName")}
+            />
+          </div>
+          <div className="w-full p-[2.4rem]">
+            <Button
+              type="submit"
+              variant="primary"
+              size="lg"
+              className="flex w-full justify-center"
+            >
+              수정하기
+            </Button>
+          </div>
+        </form>
+      </Popup>
       <CompareShareModal
         shareCode={shareCode}
         active={shareModal.active}
         deactivate={shareModal.deactivate}
       />
+      <LoadingIndicator active={isMetaDataLoading} />
     </>
   );
 };


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 비교표 수정 모달 만들었고, 수정하기 api 도 연결했습니다 

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

https://github.com/user-attachments/assets/4940f105-75c6-4d10-8435-2d7494874358


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 비교표 이름을 수정할 수 있는 편집 모달(“표 수정하기”)을 추가했습니다. 기본값 표시, 20자 입력 제한, 미입력 시 기존 이름을 유지합니다.
  - 비교 타일에서 편집 클릭 시 모달이 열리고, 저장 시 변경사항이 적용되며 성공 알림이 표시됩니다. 저장 후 모달은 자동으로 닫힙니다.
  - 메타데이터 조회 중 로딩 인디케이터를 표시해 진행 상황을 명확히 안내합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->