### PR TITLE
[Y26W2-351] feat(web): 숙소 리스트 페이지 UX 보강 

### DIFF
--- a/apps/web/src/app/boards/[id]/lists/page.tsx
+++ b/apps/web/src/app/boards/[id]/lists/page.tsx
@@ -173,7 +173,7 @@ const BoardsIdListsPage = () => {
               fetchNextPage={fetchNextPage}
               hasNextPage={hasNextPage}
               isFetchingNextPage={isFetchingNextPage}
-              participants={tripBoardDetail?.data.result?.participants || []}
+              tripBoardDetailData={tripBoardDetail?.data.result || {}}
             />
           </motion.div>
         )}

--- a/apps/web/src/app/boards/[id]/lists/page.tsx
+++ b/apps/web/src/app/boards/[id]/lists/page.tsx
@@ -1,9 +1,10 @@
 "use client";
-import { useGetTripBoardDetail } from "@ssok/api";
+import { useGetTripBoardDetail, useRegisterAccommodationCard } from "@ssok/api";
 import { cn, LoadingIndicator, SolidExpand } from "@ssok/ui";
 import { AnimatePresence, motion } from "framer-motion";
 import { useParams } from "next/navigation";
 import { useEffect, useState } from "react";
+import type { FieldErrors } from "react-hook-form";
 import HeaderSection from "@/domains/list/components/header-section";
 import LinkInputSection from "@/domains/list/components/link-input-section";
 import PlaceListSection from "@/domains/list/components/place-list-section";
@@ -15,6 +16,11 @@ import useDropdown from "@/domains/list/hooks/use-dropdown";
 import useInputPanel from "@/domains/list/hooks/use-input-panel";
 import useRegisterUrlInput from "@/domains/list/hooks/use-register-url-input";
 import useSession from "@/shared/hooks/use-session";
+
+type FormData = {
+  link: string;
+  memo?: string;
+};
 
 const BoardsIdListsPage = () => {
   const {
@@ -31,7 +37,7 @@ const BoardsIdListsPage = () => {
     useDragAndDrop((url) => {
       setValue("link", url);
     });
-  // TODO: 메모 입력 관련 로직 커스텀훅 분리
+
   const {
     isMemoInputVisible,
     register,
@@ -39,12 +45,37 @@ const BoardsIdListsPage = () => {
     handleMemoInputToggle,
     memoText,
     maxChars,
-    setValue,
     watch,
+    setValue,
   } = useRegisterUrlInput();
+
   const params = useParams();
   const id = params.id;
   const { accessToken } = useSession({ required: true });
+  const { mutate, isPending: IsGeneratingCard } = useRegisterAccommodationCard({
+    request: { headers: { Authorization: `Bearer ${accessToken}` } },
+  });
+
+  const onValid = (data: FormData) => {
+    if (id === undefined) return;
+    mutate(
+      {
+        data: { url: data.link, memo: data.memo, tripBoardId: Number(id) },
+      },
+      {
+        onSuccess: () => {
+          window.location.reload();
+        },
+      },
+    );
+    console.log("폼 제출 성공:", data);
+  };
+
+  const onInvalid = (errors: FieldErrors<FormData>) => {
+    alert("url은 필수로 입력해야 합니다! ✈️");
+    console.error("폼 유효성 오류:", errors);
+  };
+
   const { data: tripBoardDetail, isLoading: isTripBoardLoading } =
     useGetTripBoardDetail(Number(id), {
       query: {
@@ -112,7 +143,6 @@ const BoardsIdListsPage = () => {
             <HeaderSection {...tripBoardDetail?.data.result} />
             {/* 링크 저장 */}
             <LinkInputSection
-              watch={watch}
               isDragging={isDragging}
               isInputExpanded={isInputExpanded}
               isMemoInputVisible={isMemoInputVisible}
@@ -121,7 +151,10 @@ const BoardsIdListsPage = () => {
               handleMemoInputToggle={handleMemoInputToggle}
               handleTooltipvisible={handleTooltipvisible}
               register={register}
+              watch={watch}
               handleSubmit={handleSubmit}
+              onValid={onValid}
+              onInvalid={onInvalid}
               memoText={memoText}
               maxChars={maxChars}
             />
@@ -136,6 +169,7 @@ const BoardsIdListsPage = () => {
               isOpen={isOpen}
               selectedFilter={selectedFilter}
               isLoading={accommodationDataLoading}
+              isGeneratingCard={IsGeneratingCard}
               fetchNextPage={fetchNextPage}
               hasNextPage={hasNextPage}
               isFetchingNextPage={isFetchingNextPage}

--- a/apps/web/src/domains/list/components/link-input-section/index.tsx
+++ b/apps/web/src/domains/list/components/link-input-section/index.tsx
@@ -1,13 +1,10 @@
-import { useRegisterAccommodationCard } from "@ssok/api";
 import { cn, IcLink } from "@ssok/ui";
-import { useParams } from "next/navigation";
 import type {
   FieldErrors,
   UseFormHandleSubmit,
   UseFormRegister,
   UseFormWatch,
 } from "react-hook-form";
-import useSession from "@/shared/hooks/use-session";
 import ButtonContainer from "./atom/button-container";
 import LinkInputContainer from "./atom/link-input-container";
 import OnboardingBubble from "./atom/onboarding-bubble";
@@ -31,6 +28,8 @@ interface LinkInputSectionProps {
   handleSubmit: UseFormHandleSubmit<FormData>;
   memoText: string;
   maxChars: number;
+  onValid: (data: FormData) => void;
+  onInvalid: (errors: FieldErrors<FormData>) => void;
 }
 
 const LinkInputSection = ({
@@ -46,34 +45,9 @@ const LinkInputSection = ({
   handleSubmit,
   memoText,
   maxChars,
+  onValid,
+  onInvalid,
 }: LinkInputSectionProps) => {
-  const params = useParams();
-  const id = params.id;
-  const { accessToken } = useSession({ required: true });
-  const { mutate, isPending } = useRegisterAccommodationCard({
-    request: { headers: { Authorization: `Bearer ${accessToken}` } },
-  });
-
-  const onValid = (data: FormData) => {
-    if (id === undefined) return;
-    mutate(
-      {
-        data: { url: data.link, memo: data.memo, tripBoardId: Number(id) },
-      },
-      {
-        onSuccess: () => {
-          window.location.reload();
-        },
-      },
-    );
-    console.log("폼 제출 성공:", data);
-  };
-
-  const onInvalid = (errors: FieldErrors<FormData>) => {
-    alert("url은 필수로 입력해야 합니다! ✈️");
-    console.error("폼 유효성 오류:", errors);
-  };
-
   return (
     <section
       className={cn(
@@ -139,13 +113,6 @@ const LinkInputSection = ({
             </p>
           </div>
         </>
-      )}
-      {isPending && (
-        <main className="absolute z-10 flex h-full w-full items-center justify-center">
-          <div
-            className={`h-[2.4rem] w-[2.4rem] animate-spin rounded-full border-4 border-t-transparent bg-primary`}
-          />
-        </main>
       )}
     </section>
   );

--- a/apps/web/src/domains/list/contexts/place-select-context.tsx
+++ b/apps/web/src/domains/list/contexts/place-select-context.tsx
@@ -14,6 +14,7 @@ type PlaceSelectionContextType = {
   removePlace: (id: number) => void;
   lastSelectedPlace: number | null;
   onSelectPlace: (id: number) => void;
+  resetSelection: () => void;
 };
 
 const PlaceSelectionContext = createContext<PlaceSelectionContextType | null>(
@@ -58,6 +59,11 @@ const PlaceSelectionProvider = ({ children }: { children: ReactNode }) => {
     setSelectedPlaces((prev) => prev.filter((placeId) => placeId !== id));
   }, []);
 
+  const resetSelection = useCallback(() => {
+    setSelectedPlaces([]);
+    setLastSelectedPlace(null);
+  }, []);
+
   return (
     <PlaceSelectionContext.Provider
       value={{
@@ -66,6 +72,7 @@ const PlaceSelectionProvider = ({ children }: { children: ReactNode }) => {
         removePlace,
         lastSelectedPlace,
         onSelectPlace,
+        resetSelection,
       }}
     >
       {children}

--- a/packages/tailwind-config/src/theme.ts
+++ b/packages/tailwind-config/src/theme.ts
@@ -255,10 +255,15 @@ export const theme: Config["theme"] = {
   },
   animation: {
     "spin-reverse": "spin-reverse 1s linear infinite",
+    shimmer: "shimmer 1.5s infinite",
   },
   keyframes: {
     "spin-reverse": {
       "100%": { transform: "rotate(-360deg)" },
+    },
+    shimmer: {
+      "0%": { transform: "translateX(-100%)" },
+      "100%": { transform: "translateX(100%)" },
     },
   },
 };

--- a/packages/ui/src/components/skeleton-card/index.tsx
+++ b/packages/ui/src/components/skeleton-card/index.tsx
@@ -1,0 +1,110 @@
+"use client";
+import type React from "react";
+import { cn } from "@/utils";
+import { card } from "../card/card.variant";
+
+export interface CardSkeletonProps {
+  className?: string;
+  selected?: boolean;
+}
+
+const SkeletonBar = ({ className }: { className?: string }) => (
+  <div
+    className={cn(
+      "relative overflow-hidden rounded-[0.6rem] bg-neutral-80",
+      className,
+    )}
+  >
+    <div className="absolute inset-0 animate-[shimmer_1.5s_infinite] bg-gradient-to-r from-transparent via-white/20 to-transparent" />
+  </div>
+);
+
+const Circle = ({ className }: { className?: string }) => (
+  <div
+    className={cn("animate-pulse rounded-full bg-neutral-75", className)}
+    aria-hidden
+  />
+);
+
+const DotDivider = () => (
+  <span className="mx-[0.4rem] inline-block h-[0.2rem] w-[0.2rem] rounded-full bg-neutral-80" />
+);
+
+const CardSkeleton: React.FC<CardSkeletonProps> = ({
+  className,
+  selected = false,
+}) => {
+  return (
+    <section
+      className={cn(card({ selected }), className, "overflow-hidden")}
+      aria-busy="true"
+      aria-live="polite"
+    >
+      <div className="relative h-[16.4rem] w-[19.9rem] rounded-[1.2rem] border-[rgba(152,152,152,0.10)]">
+        <div className="h-full w-full animate-pulse rounded-[1.2rem] bg-neutral-90" />
+
+        <div className="absolute top-[0.8rem] right-[0.8rem] z-1 rounded-[0.4rem] bg-[rgba(84,84,84,0.7)] px-[0.6rem] py-[0.4rem]">
+          <div className="h-[1.6rem] w-[5.8rem]" />
+        </div>
+
+        <div className="absolute bottom-0 z-1 flex w-[-webkit-fill-available] items-center gap-[0.8rem] rounded-b-[1.2rem] bg-[linear-gradient(87deg,_rgba(0,0,0,0.6)_0%,_rgba(72,72,72,0.6)_100%)] px-[1.2rem] py-[0.8rem]">
+          <Circle className="h-[3.2rem] w-[3.2rem]" />
+        </div>
+      </div>
+
+      <article className="flex flex-col justify-between">
+        <header>
+          <div className="flex flex-col gap-[0.4rem]">
+            <SkeletonBar className="h-[2.2rem] w-[30.3rem]" />
+
+            <div className="flex flex-row items-center gap-[0.8rem]">
+              <SkeletonBar className="h-[2.0rem] w-[9rem]" />
+              <div className="flex items-center gap-[0.4rem]">
+                <Circle className="h-[2rem] w-[2rem]" />
+                <SkeletonBar className="h-[1.1rem] w-[6rem]" />
+              </div>
+            </div>
+          </div>
+
+          <div className="mt-[8px] flex flex-col gap-[0.8rem]">
+            <div className="flex items-center gap-[0.4rem]">
+              <Circle className="h-[2rem] w-[2rem]" />
+              <SkeletonBar className="h-[1.2rem] w-[24rem]" />
+            </div>
+
+            <ul className="m-0 flex list-none flex-row items-center p-0">
+              <li className="flex flex-row items-center">
+                <SkeletonBar className="h-[2rem] w-[8rem] rounded-[999px]" />
+                <DotDivider />
+              </li>
+              <li className="flex flex-row items-center">
+                <SkeletonBar className="h-[2rem] w-[7rem] rounded-[999px]" />
+                <DotDivider />
+              </li>
+              <li className="flex flex-row items-center">
+                <SkeletonBar className="h-[2rem] w-[9rem] rounded-[999px]" />
+              </li>
+            </ul>
+          </div>
+        </header>
+
+        <div className="mt-[0.4rem] flex items-center gap-[0.6rem]">
+          <Circle className="h-[1.6rem] w-[1.6rem]" />
+          <SkeletonBar className="h-[1.4rem] w-[18rem]" />
+        </div>
+      </article>
+
+      <div className="flex flex-col gap-[1.6rem]">
+        {/* Add button */}
+        <div className="flex items-center justify-center">
+          <Circle className="h-[4rem] w-[4rem]" />
+        </div>
+        <div className="hidden group-hover:block">
+          <Circle className="h-[4rem] w-[4rem]" />
+        </div>
+      </div>
+    </section>
+  );
+};
+
+export default CardSkeleton;

--- a/packages/ui/src/components/skeleton-card/skeleton-card.stories.tsx
+++ b/packages/ui/src/components/skeleton-card/skeleton-card.stories.tsx
@@ -1,0 +1,47 @@
+import type { Meta, StoryObj } from "@storybook/react-vite";
+import Card from "../card";
+import CardSkeleton from "./";
+
+const meta: Meta<typeof CardSkeleton> = {
+  title: "Components/CardSkeleton",
+  component: CardSkeleton,
+  tags: ["autodocs"],
+};
+
+export default meta;
+type Story = StoryObj<typeof CardSkeleton>;
+
+export const Default: Story = {
+  args: {},
+};
+
+export const Compare: Story = {
+  render: () => (
+    <div className="flex w-fit flex-col gap-4">
+      {/* 스켈레톤 카드 */}
+      <CardSkeleton />
+
+      {/* 실제 카드 */}
+      <Card
+        selected={false}
+        onAddClick={() => console.log("Add clicked")}
+        onDeleteClick={() => console.log("Delete clicked")}
+        images={[
+          "https://pix8.agoda.net/hotelImages/942/942521/942521_17021009050050901364.jpg?ca=6&ce=1&s=312x235&ar=16x9",
+        ]}
+        address="서울특별시 강남구 테헤란로 123"
+        url="https://agoda.com"
+        logoUrl="https://cdn6.agoda.net/images/kite-js/logo/agoda/color-default.svg"
+        siteName="아고다"
+        accommodationName="테스트 호텔"
+        currency="₩120,000"
+        nearbyAttractions={[
+          { name: "관광지 1", distance: "1km" },
+          { name: "관광지 2", distance: "2km" },
+        ]}
+        savedByText="내가 1순위로 찜한 숙소"
+        memo="테스트 메모입니다."
+      />
+    </div>
+  ),
+};

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -134,6 +134,7 @@ export {
   default as LoadingIndicator,
   type LoadingIndicatorProps,
 } from "./components/loading-indicator";
+export { default as SkeletonCard } from "./components/skeleton-card";
 export { default as Switch, type SwitchProps } from "./components/switch";
 export { default as TextWithIcon } from "./components/text-with-icon";
 export {


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 숙소 추가 동작시, isPending 상태에서 skeleton UI가 랜더링되도록 했습니다. 
- 비교표 생성시, tableName을 boardName 기반으로 자동 설정할 수 있도록 했습니다.
- 비교표 생성 + 숙소 데이터 isLoading 상태에서 스피너가 작동합니다 .
- 비교표 생성 이후로, selectedAccommodation 값을 초기화해주었습니다 

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

https://github.com/user-attachments/assets/51ac580d-bc95-4464-b027-81924a6cc11b


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->
