### PR TITLE
[Y26W2-352] fix(web): 랜딩 페이지 버튼 텍스트 수정

### DIFF
--- a/apps/web/src/domains/landing/components/hero-section/index.tsx
+++ b/apps/web/src/domains/landing/components/hero-section/index.tsx
@@ -41,7 +41,7 @@ const HeroSection = () => {
             )}
           >
             <span className="text-title3-semi24">
-              신나는 여행 준비 시작하기
+              설레는 여행 준비 시작하기
             </span>
             <IcArrowRight className="h-[3.2rem] w-[3.2rem]" />
           </Button>


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- `신나는` -> `설레는`

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 스타일
  * 랜딩 페이지 히어로 섹션의 주요 CTA 문구를 “신나는 여행 준비 시작하기”에서 “설레는 여행 준비 시작하기”로 업데이트하여 어조를 더 설레는 느낌으로 다듬었습니다. 라우팅(/boards 링크), 레이아웃, 버튼 위치 및 인터랙션은 기존과 동일하며 다른 화면 요소에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->