### PR TITLE
[Y26W2-353] feat(web): 비교표 공유 구현

### DIFF
--- a/apps/web/src/domains/compare/api/index.ts
+++ b/apps/web/src/domains/compare/api/index.ts
@@ -1,0 +1,107 @@
+import {
+  type GetComparisonTableByShareCodeQueryError,
+  type GetComparisonTableByShareCodeQueryResult,
+  type GetComparisonTableQueryError,
+  type GetComparisonTableQueryResult,
+  getGetComparisonTableByShareCodeQueryKey,
+  getGetComparisonTableByShareCodeQueryOptions,
+  getGetComparisonTableQueryKey,
+  getGetComparisonTableQueryOptions,
+  prefetchGetComparisonTableByShareCodeQuery,
+  prefetchGetComparisonTableQuery,
+  type useGetComparisonTable,
+  type useGetComparisonTableByShareCode,
+} from "@ssok/api";
+import type { GetComparisonTableByShareCodeParams } from "@ssok/api/schemas";
+import {
+  type DataTag,
+  type DefinedUseQueryResult,
+  type QueryClient,
+  type QueryKey,
+  type UseQueryOptions,
+  useQuery,
+} from "@tanstack/react-query";
+
+export const prefetchComparisonTableQuery = (
+  queryClient: QueryClient,
+  {
+    tableId,
+    ...params
+  }:
+    | (GetComparisonTableByShareCodeParams & { tableId: number })
+    | { tableId: number },
+  options:
+    | Parameters<typeof prefetchGetComparisonTableByShareCodeQuery>[3]
+    | Parameters<typeof prefetchGetComparisonTableQuery>[2],
+) => {
+  if ("shareCode" in params && params.shareCode) {
+    return prefetchGetComparisonTableByShareCodeQuery(
+      queryClient,
+      tableId,
+      params as GetComparisonTableByShareCodeParams,
+      options as Parameters<
+        typeof prefetchGetComparisonTableByShareCodeQuery
+      >[3],
+    );
+  } else {
+    return prefetchGetComparisonTableQuery(
+      queryClient,
+      tableId,
+      options as Parameters<typeof prefetchGetComparisonTableQuery>[2],
+    );
+  }
+};
+
+export const getComparisonTableQueryKey = ({
+  tableId,
+  ...params
+}:
+  | (GetComparisonTableByShareCodeParams & { tableId: number })
+  | { tableId: number }) => {
+  if ("shareCode" in params && params.shareCode) {
+    return getGetComparisonTableByShareCodeQueryKey(tableId, {
+      shareCode: params.shareCode,
+    } satisfies GetComparisonTableByShareCodeParams);
+  }
+
+  return getGetComparisonTableQueryKey(tableId);
+};
+
+export const useComparisonTableQuery = (
+  {
+    tableId,
+    ...params
+  }:
+    | (GetComparisonTableByShareCodeParams & { tableId: number })
+    | { tableId: number },
+  options:
+    | Parameters<typeof useGetComparisonTableByShareCode>[2]
+    | Parameters<typeof useGetComparisonTable>[1],
+  queryClient?: QueryClient,
+) => {
+  const queryOptions =
+    "shareCode" in params && params.shareCode
+      ? getGetComparisonTableByShareCodeQueryOptions(
+          tableId,
+          params,
+          options as Parameters<typeof useGetComparisonTableByShareCode>[2],
+        )
+      : getGetComparisonTableQueryOptions(
+          tableId,
+          options as Parameters<typeof useGetComparisonTable>[1],
+        );
+
+  const query = useQuery(
+    queryOptions as UseQueryOptions,
+    queryClient,
+  ) as DefinedUseQueryResult<
+    GetComparisonTableByShareCodeQueryResult | GetComparisonTableQueryResult,
+    GetComparisonTableByShareCodeQueryError | GetComparisonTableQueryError
+  > & {
+    queryKey: DataTag<QueryKey, unknown, unknown>;
+  };
+
+  query.queryKey = queryOptions.queryKey;
+
+  return query;
+};

--- a/apps/web/src/domains/compare/hooks/use-comparison-table.ts
+++ b/apps/web/src/domains/compare/hooks/use-comparison-table.ts
@@ -1,9 +1,5 @@
-import {
-  getGetComparisonTableQueryKey,
-  useGetComparisonTable,
-} from "@ssok/api";
-import { useQueryClient } from "@tanstack/react-query";
 import { useMemo } from "react";
+import { useComparisonTableQuery } from "@/domains/compare/api";
 import type { ComparisonFormData } from "@/domains/compare/types";
 import { transformComparisonTableResponseToFormData } from "@/domains/compare/utils/form";
 import useSession from "@/shared/hooks/use-session";
@@ -11,22 +7,25 @@ import useSession from "@/shared/hooks/use-session";
 const useComparisonTable = ({
   boardId,
   tableId,
+  shareCode,
 }: {
   boardId: number;
   tableId: number;
+  shareCode?: string;
 }) => {
-  const queryClient = useQueryClient();
-  const { accessToken } = useSession({ required: true });
+  const { accessToken } = useSession({ required: !shareCode });
 
-  const { data, isLoading: isMetaDataLoading } = useGetComparisonTable(
-    tableId,
+  const { data, isLoading: isMetaDataLoading } = useComparisonTableQuery(
+    { tableId, shareCode },
     {
       query: {
-        enabled:
-          !!accessToken ||
-          !!queryClient.getQueryData(getGetComparisonTableQueryKey(tableId)),
+        enabled: !!tableId && (!!accessToken || !!shareCode),
       },
-      request: { headers: { Authorization: `Bearer ${accessToken}` } },
+      request: {
+        headers: accessToken
+          ? { Authorization: `Bearer ${accessToken}` }
+          : undefined,
+      },
     },
   );
 

--- a/apps/web/src/domains/compare/views/compare-page-view/index.tsx
+++ b/apps/web/src/domains/compare/views/compare-page-view/index.tsx
@@ -20,15 +20,21 @@ import useSession from "@/shared/hooks/use-session";
 interface ComparePageViewProps {
   boardId: number;
   tableId: number;
+  shareCode?: string;
 }
 
-const ComparePageView = ({ boardId, tableId }: ComparePageViewProps) => {
+const ComparePageView = ({
+  boardId,
+  tableId,
+  shareCode,
+}: ComparePageViewProps) => {
   const { currentView, handleViewChange } = useViewMode();
   const queryClient = useQueryClient();
   const { accessToken } = useSession();
   const { formData, response, isMetaDataLoading } = useComparisonTable({
     boardId,
     tableId,
+    shareCode,
   });
   const mutation = useUpdateComparisonTable({
     request: { headers: { Authorization: `Bearer ${accessToken}` } },


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 비교표 공유하기 링크를 통해 접속하는 경우를 위해 API를 맞춰 수정했습니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
commit-id:6508cfa0

---

**Stack**:
- #172
- #171
- #170
- #169
- #168
- #167 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - 공유 코드로 비교 테이블을 로그인 없이 열람할 수 있습니다.
  - 공유 링크 접속 시 코드가 자동 인식되어 콘텐츠가 로드됩니다.
  - 인증이 필요한 경우 로그인 페이지로 이동 후 원래 대상 페이지로 복귀합니다.
- Refactor
  - 비교 테이블 데이터 조회를 통합해 공유 코드/일반 접근을 단일 흐름으로 처리했습니다.
  - 사전 로딩과 훅 사용 방식을 단순화하고, 필요 시에만 인증 헤더를 전송하도록 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->