### PR TITLE
[Y26W2-353] chore(web): 비회원 대응을 위한 사이드바 프로필 아바타 수정

### DIFF
--- a/apps/web/src/shared/components/side-navigation/atom/profile-menu.tsx
+++ b/apps/web/src/shared/components/side-navigation/atom/profile-menu.tsx
@@ -27,7 +27,7 @@ export const ModalConfig = {
 
 const ProfileMenu = () => {
   const router = useRouter();
-  const { accessToken } = useSession({ required: true });
+  const { accessToken, isPending: isSessionPending } = useSession();
   const { data: userInfo, isLoading } = useGetUserInfo({
     query: { enabled: !!accessToken },
     request: { headers: { Authorization: `Bearer ${accessToken}` } },
@@ -52,6 +52,10 @@ const ProfileMenu = () => {
   const onToggleMenu = () => setIsMenuOpen((prev) => !prev);
 
   useOutsideClick(menuRef, () => onCloseMenu());
+
+  if (!accessToken && !isSessionPending) {
+    return null;
+  }
 
   return (
     <>

--- a/apps/web/src/shared/hooks/use-session.ts
+++ b/apps/web/src/shared/hooks/use-session.ts
@@ -22,6 +22,7 @@ export interface UseSessionResult {
   accessToken: string | null;
   isAuthenticated: boolean;
   isLoading: boolean;
+  isPending: boolean;
   error: Error | null;
   refetch: () => void;
 }
@@ -64,6 +65,7 @@ const useSession = ({
     accessToken: result?.tokenSet.accessToken || null,
     isAuthenticated: Boolean(result?.tokenSet.accessToken),
     isLoading: query.isLoading,
+    isPending: query.isPending,
     error: query.error,
     refetch: query.refetch,
   };


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 사이드바의 사용자 프로필 정보를 반드시 가져오면서 실패하고 로그인 페이지로 이동하는 경우가 있어서, 이를 수정했습니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
commit-id:e03a1b88

---

**Stack**:
- #172
- #171
- #170
- #169
- #168 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 없음
- 버그 수정
  - 로그인되지 않은 경우 프로필 메뉴가 표시되지 않도록 해 의도치 않은 노출을 방지했습니다.
  - 로딩 지표가 대기 상태까지 반영되어 불필요한 깜빡임과 잘못된 로딩 표시를 감소했습니다.
- 리팩터
  - 세션 확인을 비차단 방식으로 조정해 초기 화면 렌더링을 더 빠르게 했습니다.
  - 로딩 상태 관리를 단순화하여 사용자 정보/작업 진행 상황을 일관되게 표시합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->