### PR TITLE
[Y26W2-353] chore(web): 비회원 및 초대 사용자의 비교표 버튼 노출 수정

### DIFF
--- a/apps/web/src/domains/compare/components/compare-page-title/index.tsx
+++ b/apps/web/src/domains/compare/components/compare-page-title/index.tsx
@@ -20,6 +20,8 @@ export interface ComparePageTitleProps {
   onViewChange: (view: ViewMode) => void;
   onSave: () => void;
   isLoading?: boolean;
+  isAuthenticated: boolean;
+  isAccessedByShareCode: boolean;
   className?: string;
 }
 
@@ -29,6 +31,8 @@ const ComparePageTitle = ({
   onViewChange,
   onSave,
   isLoading = false,
+  isAuthenticated,
+  isAccessedByShareCode,
   className,
 }: ComparePageTitleProps) => {
   const { control } = useFormContext<ComparisonFormData>();
@@ -37,6 +41,9 @@ const ComparePageTitle = ({
     deactivate: closeShareModal,
     active: isShareModalOpen,
   } = useToggle();
+
+  const isBoardMember = isAuthenticated && !isAccessedByShareCode;
+
   return (
     <div className={cn("flex items-center justify-between", className)}>
       <Controller
@@ -54,20 +61,29 @@ const ComparePageTitle = ({
         {currentView === "table" && (
           <>
             <MapButton onClick={() => onViewChange("map")} />
-            <EditButton onClick={() => onViewChange("edit")} />
-            <ShareButton onClick={openShareModal} />
+            {isBoardMember && (
+              <>
+                <EditButton onClick={() => onViewChange("edit")} />
+                <ShareButton onClick={openShareModal} />
+              </>
+            )}
           </>
         )}
         {currentView === "map" && (
           <>
             <TableButton onClick={() => onViewChange("table")} />
-            <EditButton onClick={() => onViewChange("edit")} />
-            <ShareButton onClick={openShareModal} />
+            {isBoardMember && (
+              <>
+                <EditButton onClick={() => onViewChange("edit")} />
+                <ShareButton onClick={openShareModal} />
+              </>
+            )}
           </>
         )}
         {currentView === "edit" && (
           <SaveButton onClick={onSave} isLoading={isLoading} />
         )}
+        {!isAuthenticated && <LoginButton />}
       </div>
       <CompareShareModal
         shareCode={shareCode}
@@ -151,6 +167,22 @@ const SaveButton = ({
       disabled={isLoading}
     >
       저장하기
+    </Button>
+  );
+};
+
+const LoginButton = () => {
+  return (
+    <Button
+      type="button"
+      size="lg"
+      variant="primary"
+      onClick={() => {
+        const to = window.location.pathname + window.location.search;
+        window.location.href = `/api/auth/login?to=${encodeURIComponent(to)}`;
+      }}
+    >
+      로그인
     </Button>
   );
 };

--- a/apps/web/src/domains/compare/views/compare-page-view/index.tsx
+++ b/apps/web/src/domains/compare/views/compare-page-view/index.tsx
@@ -30,7 +30,7 @@ const ComparePageView = ({
 }: ComparePageViewProps) => {
   const { currentView, handleViewChange } = useViewMode();
   const queryClient = useQueryClient();
-  const { accessToken } = useSession();
+  const { accessToken, isAuthenticated } = useSession();
   const { formData, response, isMetaDataLoading } = useComparisonTable({
     boardId,
     tableId,
@@ -87,6 +87,8 @@ const ComparePageView = ({
             handleViewChange("table");
           }}
           isLoading={mutation.isPending}
+          isAuthenticated={isAuthenticated}
+          isAccessedByShareCode={Boolean(shareCode)}
           className="mb-[3.2rem] shrink-0"
         />
 


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 비회원 및 초대 받은 사용자의 비교표 버튼 노출을 수정했습니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
commit-id:e846e1c7

---

**Stack**:
- #172
- #171
- #170
- #169 ⬅


⚠️ *Part of a stack created by [spr](https://github.com/ejoffe/spr). Do not merge manually using the UI - doing so may have unexpected results.*

<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 비교 페이지 제목 영역에 로그인되지 않은 경우 ‘로그인’ 버튼이 표시되며, 로그인 후 현재 보던 경로로 복귀합니다.
  * 편집/공유 버튼은 보드 구성원으로 접근한 경우에만 노출됩니다. 공유 코드(링크)로 접근한 사용자는 해당 버튼이 표시되지 않습니다.
  * 이 노출 조건은 테이블·지도 보기 모두에 적용됩니다.
  * 편집 보기의 저장 기능과 공유 모달 동작은 기존과 동일합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->