### PR TITLE
[Y26W2-367] chore(web): 저장된 숙소 padding 조정

### DIFF
--- a/apps/web/src/domains/list/components/place-list-section/index.tsx
+++ b/apps/web/src/domains/list/components/place-list-section/index.tsx
@@ -148,7 +148,7 @@ const PlaceListSection = ({
       )}
     >
       {/* 숙소 리스트_제목 */}
-      <div className="flex flex-col gap-[1.6rem] p-[2.4rem]">
+      <div className="flex flex-col gap-[1.6rem] pb-[2.4rem]">
         <h1 className="text-heading1-semi20"> 저장된 숙소</h1>
         <ul className="flex w-max flex-row gap-[0.8rem]">
           <li key="all">


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 저장된 숙소 부분의 padding을 삭제하고, bottom 부분만 주도록 수정했습니다 

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

<img width="1164" height="671" alt="image" src="https://github.com/user-attachments/assets/09a89627-69a9-4052-b567-20b044bdfdff" />


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 스타일
  * 리스트 섹션의 내부 여백을 전체에서 하단 전용으로 조정하여 상·좌·우 공백을 줄이고 콘텐츠 밀착도를 개선했습니다.
  * 요소 간 간격을 정돈해 스크롤 영역 활용도를 높이고 시각적 균형을 강화했습니다.
  * 작은 화면에서 유효 표시 영역이 확대되어 가독성과 사용성이 향상됩니다.
  * 기능이나 동작 변화 없이 시각적 레이아웃만 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->