### PR TITLE
[Y26W2-358] feat(web): 숙소 핀 선택 여부에 따른 zoom level 조절

### DIFF
--- a/apps/web/src/shared/components/map-component/index.tsx
+++ b/apps/web/src/shared/components/map-component/index.tsx
@@ -35,6 +35,8 @@ const MapComponent = ({ className }: MapComponentProps) => {
         }
       : defaultCenter;
 
+  const zoom = lastSelectedPlace ? 15 : 11;
+
   return (
     <div className={cn("relative h-screen w-full", className)}>
       <GoogleMapReact
@@ -42,7 +44,7 @@ const MapComponent = ({ className }: MapComponentProps) => {
           key: process.env.NEXT_PUBLIC_GOOGLE_MAP_API_KEY,
         }}
         center={center}
-        defaultZoom={15}
+        zoom={zoom}
         // TODO: 지도 스타일링 옵션 변경
         options={{
           styles: [


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 초기 화면 랜더링시, 숙소를 선택하지 않았을때 기본적으로 모든핀이 최대한 보일 수 있도록 zoom 범위를 넓게 보여주고,
- 특정 숙소를 선택시 zoom 이 당겨지도록 설정했습니다 

## ✅ 체크리스트

- [ ] 기능 동작 확인
- [ ] 코드 리뷰 반영
- [ ] 테스트 통과
- [ ] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

https://github.com/user-attachments/assets/41db8bc9-2a08-49b5-93e8-900a85f3c016


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 지도 확대 수준이 상황에 따라 자동 조정됩니다. 최근에 장소를 선택했다면 더 가까운 수준으로, 선택하지 않았다면 넓은 범위를 표시합니다(각각 15/11 수준). 이를 통해 선택한 장소는 더 상세하게, 미선택 시에는 주변 맥락을 넓게 확인할 수 있습니다. 지도 중심 및 기타 표시 옵션은 기존과 동일하게 유지됩니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->