### PR TITLE
[Y26W2-359] chore(web): 로고 텍스트 범위까지 링크이동 지원 및 링크 새창열기

### DIFF
--- a/packages/ui/src/components/card/index.tsx
+++ b/packages/ui/src/components/card/index.tsx
@@ -86,18 +86,25 @@ const Card = ({
         <span className="absolute top-[0.8rem] right-[0.8rem] z-1 rounded-[0.4rem] bg-[rgba(21,29,25,0.70)] px-[0.6rem] py-[0.4rem] text-caption1-medi12 text-primary-100">
           {savedByText}
         </span>
-        <div className="absolute bottom-0 z-1 flex w-[-webkit-fill-available] items-center gap-[0.8rem] rounded-br-[1.2rem] rounded-bl-[1.2rem] bg-[linear-gradient(87deg,_rgba(0,0,0,0.6)_0%,_rgba(72,72,72,0.6)_100%)] px-[1.2rem] py-[0.8rem]">
-          <ImageCard
-            as={logoAs}
-            className="h-[3.2rem] w-[3.2rem] rounded-full object-cover"
-            src={logoUrl}
-            alt={siteName}
-          />
+        <div className="absolute bottom-0 z-1 w-[-webkit-fill-available] rounded-br-[1.2rem] rounded-bl-[1.2rem] bg-[linear-gradient(87deg,_rgba(0,0,0,0.6)_0%,_rgba(72,72,72,0.6)_100%)] px-[1.2rem] py-[0.8rem]">
           <a
+            target="_blank"
+            rel="noopener noreferrer"
             href={url}
-            className="text-caption1-semi12 text-primary-100 no-underline"
+            onClick={(e) => {
+              e.stopPropagation();
+            }}
+            className="flex items-center gap-[0.8rem]"
           >
-            {siteName}
+            <ImageCard
+              as={logoAs}
+              className="h-[3.2rem] w-[3.2rem] rounded-full object-cover"
+              src={logoUrl}
+              alt={siteName}
+            />
+            <p className="text-caption1-semi12 text-primary-100 no-underline">
+              {siteName}
+            </p>
           </a>
         </div>
       </div>


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 숙소 카드에서 숙소 정보 클릭시, 새창열기로 숙소 사이트가 열립니다
- a 태그 래핑을 로고 + 숙소 텍스트로 확대하여 적용했습니다 

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 카드 좌측 하단의 로고와 사이트명이 하나의 외부 링크로 묶여 새 탭에서 열리도록 개선되었습니다.
- 버그 수정
  - 로고/사이트명 클릭 시 카드 전체 클릭 이벤트가 동작하지 않도록 클릭 전파를 차단했습니다.
- 스타일
  - 로고와 사이트명을 가로 정렬하고 간격을 조정해 가독성을 향상했습니다.
  - 사이트명 텍스트 스타일을 정리하고 밑줄을 제거해 일관된 표시를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->