### PR TITLE
[Y26W2-356] feat(web): 로그인 시 header에 profile image 표시

### DIFF
--- a/apps/web/src/app/boards/new/page.tsx
+++ b/apps/web/src/app/boards/new/page.tsx
@@ -1,11 +1,30 @@
+import { prefetchGetUserInfoQuery } from "@ssok/api";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { redirect } from "next/navigation";
+import { auth } from "@/domains/auth";
 import NewUserBoardCreateView from "@/domains/dashboard/views/new-user-board-create-view";
+import getQueryClient from "@/shared/configs/tanstack-query/get-query-client";
 
 const BoardsNewPage = async () => {
-  // const session = await auth.getSession({ refresh: false });
-  // if (!session) {
-  //   redirect("/api/auth/login");
-  // }
-  return <NewUserBoardCreateView />;
+  const session = await auth.getSession({ refresh: false });
+  if (!session) {
+    redirect("/api/auth/login?to=/boards/new");
+  }
+
+  const queryClient = getQueryClient();
+  await prefetchGetUserInfoQuery(queryClient, {
+    request: {
+      headers: {
+        Authorization: `Bearer ${session.tokenSet.accessToken}`,
+      },
+    },
+  });
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <NewUserBoardCreateView />
+    </HydrationBoundary>
+  );
 };
 
 export default BoardsNewPage;

--- a/apps/web/src/app/boards/page.tsx
+++ b/apps/web/src/app/boards/page.tsx
@@ -2,6 +2,7 @@ import {
   getGetTripBoardsQueryKey,
   type getTripBoards,
   prefetchGetTripBoardsInfiniteQuery,
+  prefetchGetUserInfoQuery,
 } from "@ssok/api";
 import {
   dehydrate,
@@ -20,17 +21,27 @@ const DashboardPage = async () => {
   }
 
   const queryClient = getQueryClient();
-  await prefetchGetTripBoardsInfiniteQuery(
-    queryClient,
-    { page: 0, size: 10 },
-    {
+
+  await Promise.all([
+    prefetchGetUserInfoQuery(queryClient, {
       request: {
         headers: {
           Authorization: `Bearer ${session.tokenSet.accessToken}`,
         },
       },
-    },
-  );
+    }),
+    prefetchGetTripBoardsInfiniteQuery(
+      queryClient,
+      { page: 0, size: 10 },
+      {
+        request: {
+          headers: {
+            Authorization: `Bearer ${session.tokenSet.accessToken}`,
+          },
+        },
+      },
+    ),
+  ]);
 
   const data = queryClient.getQueryData<
     InfiniteData<Awaited<ReturnType<typeof getTripBoards>>>

--- a/apps/web/src/app/page.tsx
+++ b/apps/web/src/app/page.tsx
@@ -1,7 +1,26 @@
+import { prefetchGetUserInfoQuery } from "@ssok/api";
+import { dehydrate, HydrationBoundary } from "@tanstack/react-query";
+import { auth } from "@/domains/auth";
 import IndexPageView from "@/domains/landing/views/index-page-view";
+import getQueryClient from "@/shared/configs/tanstack-query/get-query-client";
 
-const IndexPage = () => {
-  return <IndexPageView />;
+const IndexPage = async () => {
+  const session = await auth.getSession({ refresh: false });
+  const queryClient = getQueryClient();
+
+  if (session) {
+    await prefetchGetUserInfoQuery(queryClient, {
+      request: {
+        headers: { Authorization: `Bearer ${session.tokenSet.accessToken}` },
+      },
+    });
+  }
+
+  return (
+    <HydrationBoundary state={dehydrate(queryClient)}>
+      <IndexPageView />
+    </HydrationBoundary>
+  );
 };
 
 export default IndexPage;

--- a/apps/web/src/domains/dashboard/views/dashboard-view.tsx
+++ b/apps/web/src/domains/dashboard/views/dashboard-view.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useGetTripBoardsInfinite, useGetUserInfo } from "@ssok/api";
+import { useGetTripBoardsInfinite } from "@ssok/api";
 
 import { ActionCard, LoadingIndicator, Popup } from "@ssok/ui";
 import { useEffect, useState } from "react";
@@ -31,11 +31,6 @@ const DashboardView = () => {
     },
   );
 
-  const { data: userInfo, isLoading } = useGetUserInfo({
-    query: { enabled: !!accessToken },
-    request: { headers: { Authorization: `Bearer ${accessToken}` } },
-  });
-
   const allTripBoards =
     pages?.flatMap((page) => page?.data.result?.tripBoards ?? []) ?? [];
 
@@ -48,7 +43,7 @@ const DashboardView = () => {
   return (
     <main>
       {/* 페이지 헤더 */}
-      <Header userInfo={userInfo?.data?.result || null} />
+      <Header />
       {/* 제목 + 여행 보드 목록 */}
       <section className="px-[10.4rem] pt-[7.2rem]">
         <h1 className="mb-[3.6rem] text-neutral-10 text-title1-semi36">
@@ -67,7 +62,7 @@ const DashboardView = () => {
             </li>
           ))}
         </ul>
-        <LoadingIndicator active={isFetching || isLoading} />
+        <LoadingIndicator active={isFetching} />
       </section>
       <Popup
         title="새 여행 만들기"

--- a/apps/web/src/domains/dashboard/views/new-user-board-create-view/index.tsx
+++ b/apps/web/src/domains/dashboard/views/new-user-board-create-view/index.tsx
@@ -1,24 +1,13 @@
 "use client";
 
-import { useGetUserInfo } from "@ssok/api";
-import { LoadingIndicator } from "@ssok/ui";
 import Header from "@/shared/components/header";
-import useSession from "@/shared/hooks/use-session";
 import BoardCreateForm from "../../components/board-create-form";
 import DashboardVideoBackground from "../../components/dashboard-video-background";
 
 const NewUserBoardCreateView = () => {
-  const { accessToken } = useSession({ required: true });
-  const { data: userInfo, isLoading } = useGetUserInfo({
-    query: { enabled: !!accessToken },
-    request: { headers: { Authorization: `Bearer ${accessToken}` } },
-  });
   return (
     <div className="flex h-screen flex-col bg-neutral-98">
-      <Header
-        className="shrink-0 grow-0"
-        userInfo={userInfo?.data.result || {}}
-      />
+      <Header className="shrink-0 grow-0" />
       <div className="flex flex-1">
         <DashboardVideoBackground className="h-full w-full max-w-[min(calc(100%-52rem),81.6rem)] max-md:hidden" />
 
@@ -34,7 +23,6 @@ const NewUserBoardCreateView = () => {
           <BoardCreateForm className="mr-auto w-full max-w-[45.6rem]" />
         </section>
       </div>
-      <LoadingIndicator active={isLoading} />
     </div>
   );
 };

--- a/apps/web/src/shared/components/header/index.tsx
+++ b/apps/web/src/shared/components/header/index.tsx
@@ -1,18 +1,26 @@
 "use client";
 
-import type { getUserInfoResponse } from "@ssok/api";
+import { useGetUserInfo } from "@ssok/api";
 import { AvatarProfile, Button, cn } from "@ssok/ui";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import SsokLogo from "@/shared/assets/ssok-logo.svg";
+import useSession from "@/shared/hooks/use-session";
 
 export interface HeaderProps {
   className?: string;
-  userInfo?: getUserInfoResponse["data"]["result"] | null;
 }
 
-const Header = ({ className, userInfo = null }: HeaderProps) => {
-  const _pathname = usePathname();
+const Header = ({ className }: HeaderProps) => {
+  const pathname = usePathname();
+
+  const { accessToken } = useSession();
+  const { data: userInfo } = useGetUserInfo({
+    query: { enabled: !!accessToken },
+    request: { headers: { Authorization: `Bearer ${accessToken}` } },
+  });
+
+  const profileImageUrl = userInfo?.data.result?.profileImageUrl;
 
   const navItems = [
     { label: "홈", href: "/" },
@@ -21,48 +29,47 @@ const Header = ({ className, userInfo = null }: HeaderProps) => {
 
   return (
     <header
-      className={cn("w-full border-neutral-90 border-b bg-white", className)}
+      className={cn(
+        "flex h-[6.5rem] w-full items-center justify-between border-neutral-90 border-b bg-white px-[10.4rem]",
+        className,
+      )}
     >
-      <div className="mx-auto flex w-full items-center justify-between px-[10.4rem] py-[1.6rem]">
-        <div className="flex items-center gap-[6.4rem]">
-          <Link href="/" className="flex items-center">
-            <SsokLogo className="h-[3.2rem] w-[8rem]" />
-          </Link>
+      <div className="flex items-center gap-[6.4rem]">
+        <Link href="/" className="flex items-center">
+          <SsokLogo className="h-[3.2rem] w-[8rem]" />
+        </Link>
 
-          <nav className="flex items-center gap-[4rem]">
-            {navItems.map((item) => {
-              const isActive = _pathname === item.href;
-              return (
-                <Link
-                  key={item.href}
-                  href={item.href}
-                  className={cn(
-                    "text-body3-semi15 transition-colors",
-                    isActive ? "text-primary-60" : "text-neutral-20",
-                  )}
-                >
-                  {item.label}
-                </Link>
-              );
-            })}
-          </nav>
-        </div>
-
-        {!userInfo && (
-          <Link href="/api/auth/login?to=/boards">
-            <Button
-              variant="primary"
-              size="xs"
-              className="rounded-[0.8rem] bg-neutral-20 px-[1.6rem] py-[0.8rem] text-body1-semi16 text-white hover:bg-neutral-30 focus:bg-neutral-30 active:bg-neutral-30"
-            >
-              가입하기
-            </Button>
-          </Link>
-        )}
-        {userInfo && (
-          <AvatarProfile imgUrl={userInfo?.profileImageUrl} size={32} />
-        )}
+        <nav className="flex items-center gap-[4rem]">
+          {navItems.map((item) => {
+            const isActive = pathname === item.href;
+            return (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={cn(
+                  "text-body3-semi15 transition-colors",
+                  isActive ? "text-primary-60" : "text-neutral-20",
+                )}
+              >
+                {item.label}
+              </Link>
+            );
+          })}
+        </nav>
       </div>
+
+      {profileImageUrl && <AvatarProfile imgUrl={profileImageUrl} size={32} />}
+      {!profileImageUrl && (
+        <Link href="/api/auth/login?to=/boards">
+          <Button
+            variant="primary"
+            size="xs"
+            className="rounded-[0.8rem] bg-neutral-20 px-[1.6rem] py-[0.8rem] text-body1-semi16 text-white hover:bg-neutral-30 focus:bg-neutral-30 active:bg-neutral-30"
+          >
+            가입하기
+          </Button>
+        </Link>
+      )}
     </header>
   );
 };


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 헤더 내에서 profile image를 불러와 표시하도록 수정
- 헤더를 사용하는 페이지에서는 profile image를 prefetch / hydrate 하도록 개선

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

<img width="1595" height="173" alt="CleanShot 2025-08-22 at 00 13 27" src="https://github.com/user-attachments/assets/daefbfa1-836e-47c9-9e1d-177187835cf2" />

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신규 기능
  - 로그인 미인증 시 boards/new에서 로그인 페이지로 리다이렉트
  - 헤더가 세션 기반으로 사용자 정보 로드, 프로필 이미지 있으면 아바타 표시, 없으면 로그인 버튼 노출
- 성능 개선
  - 보드 목록과 사용자 정보 사전 요청을 병렬 처리해 초기 로딩 단축
  - 서버 측 사전 패칭과 상태 하이드레이션으로 초기 화면 렌더링 개선
- 리팩터링
  - 대시보드/신규 보드 생성 화면의 사용자 정보 클라이언트 요청 제거
  - 헤더에서 userInfo 프롭 제거, 경로 기반 활성 메뉴 처리
- 스타일
  - 헤더 레이아웃 및 클래스 구조 업데이트

<!-- end of auto-generated comment: release notes by coderabbit.ai -->