### PR TITLE
[Y26W2-362] fix(web): 비교표 편집하기에서 항목 내 텍스트를 모두 지우면, 항목 자체가 사라지는 문제 수정

### DIFF
--- a/apps/web/src/domains/compare/components/compare-table/index.tsx
+++ b/apps/web/src/domains/compare/components/compare-table/index.tsx
@@ -33,7 +33,7 @@ const CompareTable = ({
   onAddCellClick,
   className,
 }: CompareTableProps) => {
-  const { handleViewChange } = useViewMode();
+  const { handleViewChange, currentView } = useViewMode();
   const { watch } = useFormContext<ComparisonFormData>();
 
   const items = watch("accommodationRequestList") || [];
@@ -48,6 +48,11 @@ const CompareTable = ({
     { key: "checkInOut", label: "체크인 / 아웃 시간" },
     { key: "reviewSummary", label: "리뷰 요약" },
   ];
+
+  // biome-ignore lint/suspicious/noExplicitAny: 어느 값이든 허용
+  const isEmpty = (value: any): value is null | undefined | "" => {
+    return value === null || (["table", "map"].includes(currentView) && !value);
+  };
 
   const handleAddCellClick = () => {
     // 인증된 사용자이고 shareCode로 접속하지 않은 경우에만 편집 모드로 이동
@@ -79,7 +84,7 @@ const CompareTable = ({
           />
         );
       case "reviewScore":
-        if (!item.reviewScore) {
+        if (isEmpty(item.reviewScore)) {
           return <AddCell state={state} onClick={handleAddCellClick} />;
         }
         return (
@@ -89,7 +94,7 @@ const CompareTable = ({
           />
         );
       case "cleanlinessScore":
-        if (!item.cleanlinessScore) {
+        if (isEmpty(item.cleanlinessScore)) {
           return <AddCell state={state} onClick={handleAddCellClick} />;
         }
         return (
@@ -99,7 +104,7 @@ const CompareTable = ({
           />
         );
       case "nearbyAttractions":
-        if (!item.nearbyAttractions) {
+        if (isEmpty(item.nearbyAttractions)) {
           return <AddCell state={state} onClick={handleAddCellClick} />;
         }
         return (
@@ -110,7 +115,7 @@ const CompareTable = ({
           />
         );
       case "amenities":
-        if (!item.amenities) {
+        if (isEmpty(item.amenities)) {
           return <AddCell state={state} onClick={handleAddCellClick} />;
         }
         return (
@@ -121,7 +126,7 @@ const CompareTable = ({
           />
         );
       case "nearbyTransportation":
-        if (!item.nearbyTransportation) {
+        if (isEmpty(item.nearbyTransportation)) {
           return <AddCell state={state} onClick={handleAddCellClick} />;
         }
         return (
@@ -133,7 +138,11 @@ const CompareTable = ({
         );
       case "checkInOut": {
         const { checkInTime, checkOutTime } = item;
-        if (!checkInTime?.from && !checkOutTime?.to) {
+        const checkInOutData = {
+          from: checkInTime?.from,
+          to: checkOutTime?.to,
+        };
+        if (isEmpty(checkInOutData)) {
           return <AddCell state={state} onClick={handleAddCellClick} />;
         }
         return (
@@ -145,7 +154,7 @@ const CompareTable = ({
         );
       }
       case "reviewSummary":
-        if (!item.reviewSummary) {
+        if (isEmpty(item.reviewSummary)) {
           return <AddCell state={state} onClick={handleAddCellClick} />;
         }
         return (

--- a/apps/web/src/domains/compare/utils/form.ts
+++ b/apps/web/src/domains/compare/utils/form.ts
@@ -93,16 +93,36 @@ export const transformFormDataToUpdateComparisonTableRequest = (
     return Number(numericString) || 0;
   };
 
+  // biome-ignore lint/suspicious/noExplicitAny: 어느 값이든 허용
+  const convertEmptyToUndefined = (value: any): string | undefined => {
+    return value === "" ? undefined : value;
+  };
+
   return {
     ...formData,
     accommodationRequestList: formData.accommodationRequestList.map((acc) => {
       return {
         ...acc,
         lowestPrice: acc.lowestPrice ? parsePrice(acc.lowestPrice) : undefined,
-        reviewScore: acc.reviewScore ? Number(acc.reviewScore) : undefined,
-        cleanlinessScore: acc.cleanlinessScore
+        reviewScore: acc.reviewScore?.trim()
+          ? Number(acc.reviewScore)
+          : undefined,
+        cleanlinessScore: acc.cleanlinessScore?.trim()
           ? Number(acc.cleanlinessScore)
           : undefined,
+        reviewSummary: convertEmptyToUndefined(acc.reviewSummary),
+        nearbyAttractions: acc.nearbyAttractions?.map((attraction) => ({
+          ...attraction,
+          name: convertEmptyToUndefined(attraction.name),
+        })),
+        nearbyTransportation: acc.nearbyTransportation?.map((transport) => ({
+          ...transport,
+          name: convertEmptyToUndefined(transport.name),
+        })),
+        amenities: acc.amenities?.map((amenity) => ({
+          ...amenity,
+          description: convertEmptyToUndefined(amenity.description),
+        })),
       } satisfies UpdateAccommodationRequest;
     }),
   };


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 비교표 편집하기에서 항목 내 텍스트를 모두 지우면, 항목 자체가 사라지는 문제를 수정했습니다.
- 값이 null이거나, 혹은 편집 모드가 아닐 때 falsy 한 값이면 AddCell로 렌더링 되도록 보완했습니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 비교 테이블에서 뷰(테이블/지도)에 따라 빈 값 판단을 일관화해 ‘추가’ 셀 노출이 더 정확해졌습니다.
  - 체크인/체크아웃, 평점, 리뷰 요약, 편의시설, 주변 관광/교통 등 일부 항목의 빈 값 처리 오류를 수정했습니다.
  - 공백만 입력된 값이 저장·표시되던 문제를 방지하여 폼 데이터 정합성과 비교 결과의 정확성을 개선했습니다.
- 리팩터
  - 빈 값 판별과 입력 정제 로직을 중앙화하여 유지보수성을 향상했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->