### PR TITLE
[Y26W2-360] feat(web): 비교표 thumbnail 내부 숙소 정보 클릭시 link 연결

### DIFF
--- a/apps/web/src/domains/compare/components/compare-table/index.tsx
+++ b/apps/web/src/domains/compare/components/compare-table/index.tsx
@@ -57,6 +57,7 @@ const CompareTable = ({ state, className }: CompareTableProps) => {
             accommodationName={accommodationName}
             siteName={item.siteName}
             logoUrl={item.logoUrl}
+            siteLink={item.url}
             state={state}
             name={`accommodationRequestList.${index}.lowestPrice`}
           />

--- a/apps/web/src/domains/compare/components/compare-table/photo-cell.tsx
+++ b/apps/web/src/domains/compare/components/compare-table/photo-cell.tsx
@@ -8,6 +8,7 @@ export interface PhotoCellProps {
   accommodationName: string;
   siteName?: string;
   logoUrl?: string;
+  siteLink?: string;
   state: ViewState;
   name: `accommodationRequestList.${number}.lowestPrice`;
 }
@@ -18,6 +19,7 @@ const PhotoCell = ({
   siteName,
   logoUrl,
   state,
+  siteLink,
   name,
 }: PhotoCellProps) => {
   const defaultSiteName = siteName || "기본";
@@ -30,6 +32,7 @@ const PhotoCell = ({
         imgAlt="숙소 이미지"
         siteName={defaultSiteName}
         logoUrl={defaultLogoUrl}
+        siteLink={siteLink}
         placeName={accommodationName}
         className="mb-[1.6rem] h-[24.4rem] w-full"
       />

--- a/apps/web/src/shared/components/photo/index.tsx
+++ b/apps/web/src/shared/components/photo/index.tsx
@@ -73,7 +73,7 @@ const Photo = ({
       <div
         className={cn(
           "absolute bottom-0 z-10 w-full translate-y-full rounded-b-[1.2rem] bg-gradient-to-r from-neutral-0/36 to-[#272727]/48 px-[1.2rem] py-[0.8rem]",
-          "transition-transform duration-300 ease-out group-hover:translate-y-0",
+          "transition-transform duration-300 ease-out group-hover:pointer-events-auto group-hover:translate-y-0",
           state === "active" && "translate-y-0",
         )}
       >

--- a/apps/web/src/shared/components/photo/index.tsx
+++ b/apps/web/src/shared/components/photo/index.tsx
@@ -10,6 +10,7 @@ export interface PhotoProps {
   state?: "default" | "edit" | "active";
   images: string[];
   imgAlt?: string;
+  siteLink?: string;
   siteName: string;
   logoUrl: string;
   placeName: string;
@@ -22,6 +23,7 @@ const Photo = ({
   imgAlt,
   siteName,
   logoUrl,
+  siteLink,
   placeName,
 }: PhotoProps) => {
   const [emblaRef, emblaApi] = useEmblaCarousel({ loop: true });
@@ -70,15 +72,28 @@ const Photo = ({
 
       <div
         className={cn(
-          "absolute bottom-0 z-10 flex w-full translate-y-full items-center rounded-b-[1.2rem] bg-gradient-to-r from-neutral-0/36 to-[#272727]/48 px-[1.2rem] py-[0.8rem]",
+          "absolute bottom-0 z-10 w-full translate-y-full rounded-b-[1.2rem] bg-gradient-to-r from-neutral-0/36 to-[#272727]/48 px-[1.2rem] py-[0.8rem]",
           "transition-transform duration-300 ease-out group-hover:translate-y-0",
           state === "active" && "translate-y-0",
         )}
       >
-        <div className="relative mr-[0.8rem] flex h-[3.2rem] w-[3.2rem] items-center justify-center overflow-hidden rounded-full border border-[#70737C]">
-          <Image src={logoUrl} alt={siteName} width={32} height={32} />
-        </div>
-        <span className="text-caption1-semi12 text-white">{siteName}</span>
+        <a
+          href={siteLink}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex cursor-pointer items-center"
+        >
+          <div className="relative mr-[0.8rem] flex h-[3.2rem] w-[3.2rem] items-center justify-center overflow-hidden rounded-full border border-[#70737C]">
+            <Image
+              src={logoUrl}
+              alt={siteName}
+              width={32}
+              height={32}
+              className="h-full w-full object-cover"
+            />
+          </div>
+          <span className="text-caption1-semi12 text-white">{siteName}</span>
+        </a>
       </div>
     </div>
   );

--- a/apps/web/src/shared/components/photo/index.tsx
+++ b/apps/web/src/shared/components/photo/index.tsx
@@ -83,7 +83,7 @@ const Photo = ({
           rel="noopener noreferrer"
           className="flex cursor-pointer items-center"
         >
-          <div className="relative mr-[0.8rem] flex h-[3.2rem] w-[3.2rem] items-center justify-center overflow-hidden rounded-full border border-[#70737C]">
+          <div className="relative mr-[0.8rem] flex h-[3.2rem] w-[3.2rem] cursor-pointer items-center justify-center overflow-hidden rounded-full border border-[#70737C]">
             <Image
               src={logoUrl}
               alt={siteName}
@@ -92,7 +92,9 @@ const Photo = ({
               className="h-full w-full object-cover"
             />
           </div>
-          <span className="text-caption1-semi12 text-white">{siteName}</span>
+          <span className="cursor-pointer text-caption1-semi12 text-white">
+            {siteName}
+          </span>
         </a>
       </div>
     </div>


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 비교표 내부에서도 숙소 사이트에 접근할 수 있도록 코드 작성했습니다 
- 기존에는 로고 사진이 원 크기보다 작게 나오던 것을 수정하여, 동그란 부모 부분에 꽉차도록 했습니다. 

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->
