### PR TITLE
[Y26W2-364] fix(web): 보드 공유 URL 및 오류 페이지 URL 수정

### DIFF
--- a/apps/web/src/app/error/access-denied/board-list/page.tsx
+++ b/apps/web/src/app/error/access-denied/board-list/page.tsx
@@ -9,7 +9,7 @@ const ErrorAccessDeniedBoardListPage = async ({
 
   return (
     <AccessDeniedView
-      title="www.ssok.info에 대한 액세스가 거부됨"
+      title="ssok.info에 대한 액세스가 거부됨"
       description="이 보드를 볼 수 있는 권한이 없어요."
       errorCode="HTTP ERROR 403"
       buttonText="다시 시도"

--- a/apps/web/src/domains/dashboard/hooks/use-invite.ts
+++ b/apps/web/src/domains/dashboard/hooks/use-invite.ts
@@ -30,7 +30,7 @@ export const useBoardInvite = (
   });
 
   const inviteData = invitationCode?.data.result;
-  const inviteLink = `https://www.ssok.info/boards/${tripBoardId}?code=${inviteData?.invitationCode}`;
+  const inviteLink = `${window.location.origin}/boards/${tripBoardId}?code=${inviteData?.invitationCode}`;
 
   const { mutateAsync: toggleInviteActive } = useToggleInvitationActive({
     mutation: {


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- `www.ssok.info` 대신 현재 URL 및 `ssok.info` 사용하도록 수정

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 버그 수정
  - 초대 링크가 하드코딩된 도메인 대신 현재 방문 중인 도메인(origin)을 기준으로 생성되도록 수정하여 개발/스테이징/프로덕션 등 다양한 환경에서 올바른 주소가 공유되도록 개선했습니다.
  - 접근 거부 페이지 제목에서 “www.” 접두어를 제거해 실제 도메인 표기로 정정했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->