### PR TITLE
[Y26W2-367] chore(web): 지원가능한 링크 소개 멘트 수정

### DIFF
--- a/apps/web/src/domains/list/components/link-input-section/atom/title-section.tsx
+++ b/apps/web/src/domains/list/components/link-input-section/atom/title-section.tsx
@@ -36,7 +36,7 @@ const TitleContainer = ({
         )}
         {isTooltipVisible && (
           <BubbleInfo>
-            지금은 부킹닷컴, 아고다, 호텔스컴바인 링크만 지원 중이에요
+            지금은 부킹닷컴, 아고다 링크만 지원 중이에요
           </BubbleInfo>
         )}
       </div>

--- a/apps/web/src/domains/list/components/link-input-section/atom/title-section.tsx
+++ b/apps/web/src/domains/list/components/link-input-section/atom/title-section.tsx
@@ -35,7 +35,7 @@ const TitleContainer = ({
           </TextWithIcon>
         )}
         {isTooltipVisible && (
-          <BubbleInfo>지금은·부킹닷컴,·아고다·링크만·지원·중이에요</BubbleInfo>
+          <BubbleInfo>지금은 부킹닷컴, 아고다 링크만 지원 중이에요</BubbleInfo>
         )}
       </div>
       <button type="button" onClick={toggleInputExpansion}>

--- a/apps/web/src/domains/list/components/link-input-section/atom/title-section.tsx
+++ b/apps/web/src/domains/list/components/link-input-section/atom/title-section.tsx
@@ -35,9 +35,7 @@ const TitleContainer = ({
           </TextWithIcon>
         )}
         {isTooltipVisible && (
-          <BubbleInfo>
-            지금은 부킹닷컴, 아고다 링크만 지원 중이에요
-          </BubbleInfo>
+          <BubbleInfo>지금은·부킹닷컴,·아고다·링크만·지원·중이에요</BubbleInfo>
         )}
       </div>
       <button type="button" onClick={toggleInputExpansion}>


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 호텔스컴바인 내용을 툴팁에서 삭제

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->
<img width="892" height="148" alt="45375" src="https://github.com/user-attachments/assets/287eb3fc-ee15-4dc9-8c9f-0ff761218da5" />

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 스타일
  * 링크 입력 섹션의 제목 영역 툴팁 문구를 업데이트했습니다. 안내 문구에서 지원 서비스 목록 중 '호텔스컴바인'을 제외하여 실제 제공 현황과 일치하도록 조정했습니다. 기능 동작이나 인터랙션에는 변화가 없으며, 시각적 레이아웃도 그대로 유지됩니다. 사용자에게 노출되는 텍스트만 변경됩니다. 툴팁이 표시되는 위치나 트리거 조건은 동일하며, 접근성 속성도 기존과 동일하게 유지됩니다. 불필요한 브랜드 언급을 제거해 안내가 더 명확해졌습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->