### PR TITLE
[Y26W2-365] fix(web): 인근 관광지 fallback 조건문 수정

### DIFF
--- a/packages/ui/src/components/card/card.utils.tsx
+++ b/packages/ui/src/components/card/card.utils.tsx
@@ -21,10 +21,16 @@ export const getAttractionDistance = (attraction: Attraction) => {
   let value = " ";
   let icon = <IcKm width="12px" height="12px" />;
 
-  if (attraction?.byFoot?.time || attraction?.byFoot?.distance) {
+  if (
+    attraction?.byFoot?.time !== null ||
+    attraction?.byFoot?.distance !== null
+  ) {
     value = attraction?.byFoot?.time ?? attraction?.byFoot?.distance ?? " ";
     icon = <IcWalker width="12px" height="12px" />;
-  } else if (attraction?.byCar?.time || attraction?.byCar?.distance) {
+  } else if (
+    attraction?.byCar?.time !== null ||
+    attraction?.byCar?.distance !== null
+  ) {
     value = attraction?.byCar?.time ?? attraction?.byCar?.distance ?? " ";
     icon = <IcCar width="12px" height="12px" />;
   } else if (attraction?.distance) {

--- a/packages/ui/src/components/card/card.utils.tsx
+++ b/packages/ui/src/components/card/card.utils.tsx
@@ -21,14 +21,14 @@ export const getAttractionDistance = (attraction: Attraction) => {
   let value = " ";
   let icon = <IcKm width="12px" height="12px" />;
 
-  if (attraction.byFoot) {
-    value = attraction.byFoot.time ?? attraction.byFoot.distance ?? " ";
+  if (attraction?.byFoot?.time || attraction?.byFoot?.distance) {
+    value = attraction?.byFoot?.time ?? attraction?.byFoot?.distance ?? " ";
     icon = <IcWalker width="12px" height="12px" />;
-  } else if (attraction.byCar) {
-    value = attraction.byCar.time ?? attraction.byCar.distance ?? " ";
+  } else if (attraction?.byCar?.time || attraction?.byCar?.distance) {
+    value = attraction?.byCar?.time ?? attraction?.byCar?.distance ?? " ";
     icon = <IcCar width="12px" height="12px" />;
-  } else if (attraction.distance) {
-    value = attraction.distance;
+  } else if (attraction?.distance) {
+    value = attraction?.distance;
     icon = <IcKm width="12px" height="12px" />;
   }
 


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 인근 관광지 거리 표기를 byfoot -> bycar -> distance 기준으로 하되, 내부 조건문을 수정했습니다 

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

<img width="3112" height="1802" alt="image" src="https://github.com/user-attachments/assets/25a40f1c-7a21-46e6-b268-f4f4aab170a2" />


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* 신규 기능
  * 없음
* 버그 수정
  * 도보/차량 정보가 비어 있거나 일부 값만 있는 경우에도 올바른 시간/거리 값과 아이콘이 표시되도록 수정했습니다.
  * 중첩된 정보가 존재하지만 시간/거리가 없는 경우 잘못된 아이콘으로 표시되던 문제를 해결했습니다.
* 리팩터링
  * 중첩 데이터의 존재 여부와 값 유효성을 보다 안전하게 검사하도록 내부 분기 로직을 정교화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->