### PR TITLE
[Y26W2-370] feat(web): 비교표 선택된 숙소 기반 map pin 랜더링

### DIFF
--- a/apps/web/src/domains/compare/views/compare-page-view/index.tsx
+++ b/apps/web/src/domains/compare/views/compare-page-view/index.tsx
@@ -6,6 +6,7 @@ import {
 } from "@ssok/api";
 import { Confirm, cn, LoadingIndicator, useToggle } from "@ssok/ui";
 import { useQueryClient } from "@tanstack/react-query";
+import { useEffect } from "react";
 import { FormProvider, useForm } from "react-hook-form";
 import ComparePageHeader from "@/domains/compare/components/compare-page-header";
 import ComparePageTitle from "@/domains/compare/components/compare-page-title";
@@ -14,6 +15,7 @@ import useComparisonTable from "@/domains/compare/hooks/use-comparison-table";
 import useViewMode from "@/domains/compare/hooks/use-view-mode";
 import type { ComparisonFormData } from "@/domains/compare/types";
 import { transformFormDataToUpdateComparisonTableRequest } from "@/domains/compare/utils/form";
+import { useAccommodationDataContext } from "@/domains/list/contexts/accomodation-data-context";
 import LoginPopup from "@/shared/components/login-popup";
 import useSession from "@/shared/hooks/use-session";
 
@@ -78,6 +80,12 @@ const ComparePageView = ({
       handleViewChange("table");
     }
   };
+
+  const { updateAccommodations } = useAccommodationDataContext();
+
+  useEffect(() => {
+    updateAccommodations(response?.accommodationResponsesList || []);
+  }, [response, updateAccommodations]);
 
   return (
     <FormProvider {...methods}>


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 비교표 세부 페이지 내부에서, 선택된 숙소에 한하여 지도 내부 pin이 랜더링되도록 context에 update 시켜주었습니다

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

<img width="3390" height="1830" alt="image" src="https://github.com/user-attachments/assets/a6490a87-e784-4254-b753-395c2e1d420e" />


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->
