### PR TITLE
[Y26W2-369] fix(web): 랜딩 페이지 최대 너비 고정

### DIFF
--- a/apps/web/src/domains/landing/components/cta-section/index.tsx
+++ b/apps/web/src/domains/landing/components/cta-section/index.tsx
@@ -8,7 +8,7 @@ const CTASection = () => {
   return (
     <LandingSectionContainer
       className={cn(
-        "flex flex-col items-center gap-[2.4rem] py-[10.4rem]",
+        "[&>div]:flex [&>div]:flex-col [&>div]:items-center [&>div]:gap-[2.4rem] [&>div]:py-[10.4rem]",
         "bg-gradient-to-b from-0% from-[rgba(148,255,176,0.20)] via-50% via-[rgba(177,183,230,0.20)] to-100% to-[rgba(148,255,176,0.20)]",
       )}
     >

--- a/apps/web/src/domains/landing/components/gallery-section/index.tsx
+++ b/apps/web/src/domains/landing/components/gallery-section/index.tsx
@@ -24,13 +24,8 @@ const GallerySection = () => {
   ];
 
   return (
-    <LandingSectionContainer
-      className={cn(
-        "flex flex-col gap-[8rem] py-[10.4rem]",
-        "bg-gradient-to-b from-0% from-[rgba(217,244,255,1)] to-37% to-white",
-      )}
-    >
-      <div className="flex flex-col items-center gap-[1.6rem]">
+    <div className="flex w-full flex-col gap-[8rem] bg-gradient-to-b from-0% from-[rgba(217,244,255,1)] to-37% to-white py-[10.4rem]">
+      <LandingSectionContainer className="[&>div]:flex [&>div]:flex-col [&>div]:items-center [&>div]:gap-[1.6rem]">
         <div className="flex flex-wrap items-center justify-center gap-[1.2rem]">
           <div className="text-display1-bold56 text-secondary-15">귀찮음은</div>
           <SsokLogoWithIconAndGradient />
@@ -41,35 +36,37 @@ const GallerySection = () => {
         <div className="text-display2-bold36 text-secondary-15">
           여러분은 결정만 하세요.
         </div>
-      </div>
+      </LandingSectionContainer>
 
-      <div className="-mx-[10.4rem] max-md:-mx-[4rem] flex w-screen flex-col items-center gap-[1.6rem] overflow-hidden">
-        <div className="flex justify-center gap-[1.6rem]">
-          {galleryImages.slice(0, 4).map((image, index) => (
-            <Image
-              key={index}
-              src={image.src}
-              alt={image.alt}
-              width={364}
-              height={240}
-              className="shrink-0 rounded-[1.2rem] object-cover"
-            />
-          ))}
+      <section className="w-full">
+        <div className="flex w-full flex-col items-center gap-[1.6rem] overflow-hidden">
+          <div className="flex justify-center gap-[1.6rem]">
+            {galleryImages.slice(0, 4).map((image, index) => (
+              <Image
+                key={index}
+                src={image.src}
+                alt={image.alt}
+                width={364}
+                height={240}
+                className="shrink-0 rounded-[1.2rem] object-cover"
+              />
+            ))}
+          </div>
+          <div className="flex justify-center gap-[1.6rem]">
+            {galleryImages.slice(4, 8).map((image, index) => (
+              <Image
+                key={index}
+                src={image.src}
+                alt={image.alt}
+                width={364}
+                height={240}
+                className="shrink-0 rounded-[1.2rem] object-cover"
+              />
+            ))}
+          </div>
         </div>
-        <div className="flex justify-center gap-[1.6rem]">
-          {galleryImages.slice(4, 8).map((image, index) => (
-            <Image
-              key={index}
-              src={image.src}
-              alt={image.alt}
-              width={364}
-              height={240}
-              className="shrink-0 rounded-[1.2rem] object-cover"
-            />
-          ))}
-        </div>
-      </div>
-    </LandingSectionContainer>
+      </section>
+    </div>
   );
 };
 

--- a/apps/web/src/domains/landing/components/hero-section/index.tsx
+++ b/apps/web/src/domains/landing/components/hero-section/index.tsx
@@ -9,7 +9,7 @@ const HeroSection = () => {
   return (
     <LandingSectionContainer
       className={cn(
-        "flex flex-col items-center gap-[8rem] overflow-y-hidden pt-[8rem]",
+        "[&>div]:flex [&>div]:flex-col [&>div]:items-center [&>div]:gap-[8rem] [&>div]:overflow-y-hidden [&>div]:pt-[8rem]",
         "bg-gradient-to-b from-0% from-[rgba(148,255,176,0.35)] via-95% via-[rgba(177,183,230,0.35)] to-100% to-[rgba(191,150,255,0.2)]",
       )}
     >

--- a/apps/web/src/domains/landing/components/landing-section-container/index.tsx
+++ b/apps/web/src/domains/landing/components/landing-section-container/index.tsx
@@ -13,8 +13,10 @@ const LandingSectionContainer = ({
   className,
 }: LandingSectionContainerProps) => {
   return (
-    <section className={cn("w-full px-[10.4rem] max-md:px-[4rem]", className)}>
-      {children}
+    <section className={cn("w-full", className)}>
+      <div className="mx-auto max-w-[123.2rem] px-[10.4rem] max-md:px-[4rem]">
+        {children}
+      </div>
     </section>
   );
 };

--- a/apps/web/src/domains/landing/components/problem-banner-section/index.tsx
+++ b/apps/web/src/domains/landing/components/problem-banner-section/index.tsx
@@ -2,7 +2,7 @@ import LandingSectionContainer from "../landing-section-container";
 
 const ProblemBannerSection = () => {
   return (
-    <LandingSectionContainer className="bg-gradient-to-b from-[#EAEEFC] to-[#E0F8F6] pt-[14.8rem] pb-[10.4rem]">
+    <LandingSectionContainer className="bg-gradient-to-b from-[#EAEEFC] to-[#E0F8F6] [&>div]:pt-[14.8rem] [&>div]:pb-[10.4rem]">
       <h2 className="text-center text-display1-bold56">
         여행 준비할 때, 이런 경험 없으셨나요?
       </h2>

--- a/apps/web/src/domains/landing/components/problem-sections/index.tsx
+++ b/apps/web/src/domains/landing/components/problem-sections/index.tsx
@@ -56,8 +56,8 @@ const ProblemSections = () => {
         <LandingSectionContainer
           key={problem.id}
           className={cn(
-            "flex w-full items-start justify-between gap-[4rem] py-[16rem]",
-            "max-md:flex-col",
+            "[&>div]:flex [&>div]:w-full [&>div]:items-start [&>div]:justify-between [&>div]:gap-[4rem] [&>div]:py-[16rem]",
+            "[&>div]:max-md:flex-col",
             problem.background,
           )}
         >

--- a/apps/web/src/domains/landing/components/solution-sections/index.tsx
+++ b/apps/web/src/domains/landing/components/solution-sections/index.tsx
@@ -68,7 +68,7 @@ const SolutionSections = () => {
   ];
 
   return (
-    <LandingSectionContainer className="flex flex-col gap-[16rem] bg-white py-[10.4rem]">
+    <LandingSectionContainer className="bg-white [&>div]:flex [&>div]:flex-col [&>div]:gap-[16rem] [&>div]:py-[10.4rem]">
       {solutions.map((solution) => (
         <div key={solution.id} className="flex w-full flex-col gap-[4.8rem]">
           <div className="flex flex-col gap-[1.6rem]">


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 랜딩 페이지의 최대 너비를 제한하여 넓은 화면에서도 문제가 없도록 수정

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

<img width="1727" height="962" alt="CleanShot 2025-08-22 at 23 30 34" src="https://github.com/user-attachments/assets/d5636402-40a0-4ba3-a535-89f4fc982c57" />
<img width="1727" height="962" alt="CleanShot 2025-08-22 at 23 30 45" src="https://github.com/user-attachments/assets/b9c09af3-4e92-452c-9612-885fb1a6336f" />


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - 랜딩 섹션(CTA, 히어로, 문제, 해결)을 콘텐츠 자식 요소 기준으로 레이아웃/간격이 적용되도록 구조 정리.
  - 공통 컨테이너에 내부 래퍼를 도입해 최대 너비와 좌우 패딩을 일관화.
  - 갤러리 섹션의 DOM을 단순화하고 시맨틱 섹션 구조로 재구성.

- Style
  - 섹션 전반의 정렬, 간격, 패딩을 통일해 시각적 일관성과 반응형 동작을 개선.
  - 불필요한 전체폭 이미지 처리 제거로 레이아웃 안정성 향상.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->