### PR TITLE
[Y26W2-374] fix(web): 로그아웃 시 cookieOption 통일, 캐시 제거

### DIFF
--- a/apps/web/src/domains/auth/utils/auth-client.ts
+++ b/apps/web/src/domains/auth/utils/auth-client.ts
@@ -57,8 +57,7 @@ export class AuthClient {
     const cookieStore = await cookies();
     cookieStore.delete({
       name: this.config.sessionCookieName,
-      path: "/",
-      httpOnly: true,
+      ...this.config.cookieOptions,
     });
 
     const to = request.nextUrl.searchParams.get("to") || "/";

--- a/apps/web/src/shared/components/side-navigation/atom/profile-menu.tsx
+++ b/apps/web/src/shared/components/side-navigation/atom/profile-menu.tsx
@@ -28,7 +28,7 @@ export const ModalConfig = {
 };
 
 const ProfileMenu = () => {
-  const router = useRouter();
+  const _router = useRouter();
   const { accessToken, isPending: isSessionPending } = useSession();
   const { data: userInfo, isLoading } = useGetUserInfo({
     query: { enabled: !!accessToken },
@@ -39,7 +39,7 @@ const ProfileMenu = () => {
   });
 
   const logout = async () => {
-    router.push("/api/auth/logout?to=/");
+    window.location.href = "/api/auth/logout?to=/";
   };
 
   const { active, activate, deactivate } = useToggle(false);


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 로그아웃 시 cookieOption 통일
- 로그아웃 시 router.push를 사용하면 캐시로 session 데이터가 남아있는 것처럼 보일 수 있어서 (react-query의 캐시) window.location.href로 완전 새로 이동하도록 수정했습니다.
  - invalidateQuery 해도 되겠지만 로그아웃은 보통 모든 캐시 다 깔끔하게 날려주는 것이 좋을 듯해서 이렇게 구현!

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->
