### PR TITLE
[Y26W2-372] fix(web): tableName 자동 생성을 위한 null 처리 

### DIFF
--- a/apps/web/src/domains/list/components/place-list-section/index.tsx
+++ b/apps/web/src/domains/list/components/place-list-section/index.tsx
@@ -100,7 +100,6 @@ const PlaceListSection = ({
         // TODO: 보드 단건 조회 api 연결 후, tableName 변수 연결
         data: {
           tripBoardId: Number(id),
-          tableName: `${tripBoardDetailData.boardName || ""} 비교표`,
           accommodationIdList: selectedPlaces,
           factorList: [],
         },
@@ -166,7 +165,7 @@ const PlaceListSection = ({
               <Button
                 variant="round"
                 selected={selectedPerson === person.userId}
-                onClick={() => handlePersonSelect(person.userId!)}
+                onClick={() => handlePersonSelect(person.userId ?? 0)}
               >
                 {person.nickname}
               </Button>

--- a/packages/api/src/api/openapi.json
+++ b/packages/api/src/api/openapi.json
@@ -1671,7 +1671,7 @@
         "type": "object",
         "properties": {
           "tripBoardId": { "type": "integer", "format": "int64" },
-          "tableName": { "type": "string", "minLength": 1 },
+          "tableName": { "type": "string" },
           "accommodationIdList": {
             "type": "array",
             "items": { "type": "integer", "format": "int64" },

--- a/packages/api/src/index.schemas.ts
+++ b/packages/api/src/index.schemas.ts
@@ -362,7 +362,6 @@ export interface StandardResponseOauthLoginResponse {
 
 export interface CreateComparisonTableRequest {
   tripBoardId: number;
-  /** @minLength 1 */
   tableName?: string;
   /** @minItems 1 */
   accommodationIdList?: number[];


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- orval 을 최신화하여 반영했습니다.
- 프론트단에서는 tableName을 보내지 않는 식으로 수정했습니다

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

<img width="3396" height="1808" alt="image" src="https://github.com/user-attachments/assets/aeef687e-d089-4f02-b0d4-e9e1324f241b" />


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* 신기능
  * 비교표 생성 시 표 이름 입력이 더 이상 필수가 아닙니다. 이름을 생략해도 생성이 가능하며 생성 흐름이 간소화되었습니다.
  * 이에 맞춰 API 스펙이 업데이트되어 클라이언트/서버 간 동작 일관성이 개선되었습니다.
* 버그 수정
  * 일부 사용자 정보가 비어있는 경우 참가자 버튼 클릭 시 발생하던 오류를 방지하여 상호작용이 더 안정적으로 동작합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->