### PR TITLE
[Y26W2-375] feat(web): 랜딩 페이지 푸터 이용약관, 개인정보처리방침, 문의메일 외부링크 연결

### DIFF
--- a/apps/web/src/shared/components/footer/index.tsx
+++ b/apps/web/src/shared/components/footer/index.tsx
@@ -21,14 +21,12 @@ const Footer = () => {
             서비스 이용약관
           </Link>
           <div className="flex items-center gap-[0.8rem]">
-            <a
+            <Link
               href="https://mail.google.com/mail/?view=cm&fs=1&to=ssok.contact@gmail.com"
-              target="_blank"
-              rel="noopener noreferrer"
               className="text-body3-semi15 text-neutral-15 transition-colors hover:text-neutral-40"
             >
               문의하기
-            </a>
+            </Link>
             <span className="text-body1-medi16 text-neutral-50">
               ssok.contact@gmail.com
             </span>

--- a/apps/web/src/shared/components/footer/index.tsx
+++ b/apps/web/src/shared/components/footer/index.tsx
@@ -9,24 +9,26 @@ const Footer = () => {
 
         <div className="flex gap-[5.6rem]">
           <Link
-            href="/rules/privacy"
+            href="https://jisuuuu.notion.site/248ca0b46ff280448723de5730098904?pvs=143"
             className="text-body3-semi15 text-neutral-15 transition-colors hover:text-neutral-40"
           >
             개인정보 처리방침
           </Link>
           <Link
-            href="/rules/service"
+            href="https://jisuuuu.notion.site/247ca0b46ff2805e9102f93a62f7c16d?source=copy_link"
             className="text-body3-semi15 text-neutral-15 transition-colors hover:text-neutral-40"
           >
             서비스 이용약관
           </Link>
           <div className="flex items-center gap-[0.8rem]">
-            <Link
-              href="mailto:ssok.contact@gmail.com"
+            <a
+              href="https://mail.google.com/mail/?view=cm&fs=1&to=ssok.contact@gmail.com"
+              target="_blank"
+              rel="noopener noreferrer"
               className="text-body3-semi15 text-neutral-15 transition-colors hover:text-neutral-40"
             >
               문의하기
-            </Link>
+            </a>
             <span className="text-body1-medi16 text-neutral-50">
               ssok.contact@gmail.com
             </span>


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 푸터 부분의 외부링크 연결을 진행했습니다

## ✅ 체크리스트

- [x[ 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 신기능
  - 없음

- 개선
  - 푸터의 ‘개인정보 처리방침’과 ‘서비스 이용약관’ 링크를 외부 페이지로 연결해 최신 문서를 바로 확인할 수 있습니다.
  - ‘문의하기’가 메일 클라이언트 대신 Gmail 작성 창으로 열리도록 변경되어 브라우저에서 즉시 문의 메일을 작성할 수 있습니다.
  - 표시 텍스트와 기타 푸터 동작은 기존과 동일합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->