### PR TITLE
[Y26W2-379] chore(web): 최대 글자 placeholder 제거

### DIFF
--- a/apps/web/src/domains/compare/components/compare-table/amenities-cell.tsx
+++ b/apps/web/src/domains/compare/components/compare-table/amenities-cell.tsx
@@ -93,7 +93,7 @@ const TableAmenity = ({
               <TextField
                 {...field}
                 value={field.value as string}
-                placeholder="필요한 정보를 기입해보세요. (최대 45자)"
+                placeholder="필요한 정보를 기입해보세요."
                 maxLength={45}
                 className="mb-[0.8rem] rounded-[0.8rem] bg-white text-body2-medi14 [&>input]:p-[0.8rem]"
               />


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 요 부분 placeholder 수정

<img width="604" height="366" alt="34487" src="https://github.com/user-attachments/assets/92f4289e-c9cd-49df-b3cd-419d8b05f6a9" />

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- 스타일
  - 비교 테이블의 편집 모드에서 편의시설 입력란 플레이스홀더 문구를 간결하게 변경: “필요한 정보를 기입해보세요.”(기존: “필요한 정보를 기입해보세요. (최대 45자)”).
  - 입력 가능 글자 수(최대 45자)는 동일하며, 편집/보기 전환 및 오류 표시 등 사용 흐름에는 영향이 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->