### PR TITLE
[Y26W2-381] fix(web): 인근 관광지 및 인근 교통편의 절대 거리 fallback mapping

### DIFF
--- a/apps/web/src/domains/compare/components/compare-table/nearby-places-cell.tsx
+++ b/apps/web/src/domains/compare/components/compare-table/nearby-places-cell.tsx
@@ -124,13 +124,17 @@ const NearbyPlace = ({
 
 const usePlaceChip = ({ place }: { place: ComparisonPlace }) => {
   return useMemo(() => {
-    if (place.byFoot?.time) {
-      return { type: "walk", icon: <IcWalker />, label: place.byFoot.time };
+    let label = "";
+    if (place.byFoot?.time || place.byCar?.distance) {
+      label = place.byFoot?.time || place.byCar?.distance || " ";
+      return { type: "walk", icon: <IcWalker />, label };
     }
-    if (place.byCar?.time) {
-      return { type: "car", icon: <IcCar />, label: place.byCar.time };
+    if (place.byCar?.time || place.byCar?.distance) {
+      label = place.byCar?.time || place.byCar?.distance || " ";
+      return { type: "car", icon: <IcCar />, label };
     }
-    return { type: "km", icon: <IcKm />, label: place.byCar?.distance || "0" };
+
+    return { type: "km", icon: <IcKm />, label: place.distance || "-" };
   }, [place]);
 };
 

--- a/apps/web/src/domains/compare/utils/form.ts
+++ b/apps/web/src/domains/compare/utils/form.ts
@@ -47,8 +47,7 @@ export const transformComparisonTableResponseToFormData = ({
                 type: attraction.type,
                 latitude: attraction.latitude,
                 longitude: attraction.longitude,
-                distance:
-                  attraction.byFoot?.distance || attraction.byCar?.distance,
+                distance: attraction.distance || undefined,
                 byFoot: attraction.byFoot,
                 byCar: attraction.byCar,
               } satisfies AttractionUpdate;
@@ -59,8 +58,7 @@ export const transformComparisonTableResponseToFormData = ({
                 type: transport.type,
                 latitude: transport.latitude,
                 longitude: transport.longitude,
-                distance:
-                  transport.byFoot?.distance || transport.byCar?.distance,
+                distance: transport.distance || undefined,
                 byFoot: transport.byFoot,
                 byCar: transport.byCar,
               } satisfies TransportationUpdate;

--- a/packages/ui/src/components/card/index.tsx
+++ b/packages/ui/src/components/card/index.tsx
@@ -10,7 +10,7 @@ import DeleteIconButton from "@/components/icon-button/delete-icon-button";
 import ImageCard from "@/components/image-card";
 import TextWithIcon from "@/components/text-with-icon";
 import { cn } from "@/utils";
-import { getAttractionDistance } from "./card.utils";
+import getAttractionDistance from "@/utils/get-attraction-distance";
 import { card } from "./card.variant";
 
 interface TransportInfo {

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -118,6 +118,7 @@ export { default as useToast } from "@/hooks/use-toast";
 export { default as useToggle } from "@/hooks/use-toggle";
 export { default as SsokUiProvider } from "@/providers/ssok-ui-provider";
 export { cn } from "@/utils";
+export { default as getAttractionDistance } from "@/utils/get-attraction-distance";
 export {
   type ActionCardProps,
   default as ActionCard,

--- a/packages/ui/src/utils/get-attraction-distance.tsx
+++ b/packages/ui/src/utils/get-attraction-distance.tsx
@@ -1,7 +1,7 @@
 import IcCar from "@/assets/icons/ic_car.svg?react";
 import IcKm from "@/assets/icons/ic_km.svg?react";
 import IcWalker from "@/assets/icons/ic_walker.svg?react";
-import type { Attraction } from ".";
+import type { Attraction } from "@/components/card";
 
 /**
  * 주어진 명소(Attraction) 객체에서 우선순위에 따라 거리 또는 시간을 추출하여,
@@ -17,7 +17,7 @@ import type { Attraction } from ".";
  *          value: 거리 또는 시간 값, 없으면 "-"
  *          icon: 거리/시간 타입에 따른 아이콘 컴포넌트
  */
-export const getAttractionDistance = (attraction: Attraction) => {
+const getAttractionDistance = (attraction: Attraction) => {
   let value = " ";
   let icon = <IcKm width="12px" height="12px" />;
 
@@ -40,3 +40,5 @@ export const getAttractionDistance = (attraction: Attraction) => {
 
   return { value, icon };
 };
+
+export default getAttractionDistance;


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 비표표 세부, 인근 교통편 / 인근 관광지의 거리를 byfoot (min - distance) ->  byCar (min - distance)  -> distance (절대거리) 를 기준으로 하며, 기존에 도보 산정 기준 및 차량 산정 시준을 따르던 코드를 수정했습니다. 

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

<img width="1701" height="908" alt="스크린샷 2025-08-23 오전 8 45 24" src="https://github.com/user-attachments/assets/a6e5dbc3-994a-430c-a030-dac59d0bba3c" />



## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - 비교 테이블의 주변 장소 칩 로직을 개선해 도보/차량/거리(km) 레이블이 더 정확하게 표시됩니다.
  - 주변 명소·교통 거리 계산을 수정해 카드와 비교 화면에서 거리 정보가 일관되게 노출됩니다.
- Refactor
  - 거리 계산 유틸리티를 통합하고 공개 API를 정리해 재사용성을 향상했습니다. 사용자 동작 변화는 없습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->