### PR TITLE
[Y26W2-384] feat(web): 보드 목록 페이지 반응형

### DIFF
--- a/apps/web/src/domains/dashboard/views/dashboard-view.tsx
+++ b/apps/web/src/domains/dashboard/views/dashboard-view.tsx
@@ -49,7 +49,7 @@ const DashboardView = () => {
         <h1 className="mb-[3.6rem] text-neutral-10 text-title1-semi36">
           나의 여행
         </h1>
-        <ul className="grid grid-cols-3 gap-[4rem]">
+        <ul className="grid gap-[4rem] max-lg:gap-[2rem] max-xl:grid-cols-2 xl:grid-cols-3">
           <li>
             <ActionCard
               onClick={() => setShowCreateModal(true)}

--- a/packages/ui/src/components/action-card/index.tsx
+++ b/packages/ui/src/components/action-card/index.tsx
@@ -19,7 +19,7 @@ const ActionCard = ({
       type="button"
       onClick={onClick}
       className={cn(
-        `flex min-h-[24.2rem] min-w-[38.4rem] flex-col items-center justify-center gap-[0.8rem] rounded-[1.6rem]`,
+        `flex min-h-[24.2rem] flex-col items-center justify-center gap-[0.8rem] rounded-[1.6rem]`,
         `border border-dashed`,
         `border-neutral-80 bg-neutral-98`,
         `hover:border-neutral-70 hover:bg-neutral-95`,

--- a/packages/ui/src/components/travel-board/index.tsx
+++ b/packages/ui/src/components/travel-board/index.tsx
@@ -75,9 +75,9 @@ const TravelBoard = ({
   return (
     <section
       className={cn(
-        `relative flex min-h-[24.2rem] min-w-[38.4rem] flex-col rounded-[1.6rem] pt-[2.4rem] pr-[2.8rem] pb-[2.4rem] pl-[3.2rem]`,
-        `border border-neutral-90 bg-neutral-99`,
-        `hover:border-neutral-80 hover:bg-neutral-98`,
+        "relative flex min-h-[24.2rem] flex-col rounded-[1.6rem] py-[2.4rem] pr-[2.8rem] pl-[3.2rem]",
+        "border border-neutral-90 bg-neutral-99",
+        "hover:border-neutral-80 hover:bg-neutral-98",
         moreHover && "border hover:border-secondary-90 hover:bg-neutral-99",
         className,
       )}
@@ -106,9 +106,9 @@ const TravelBoard = ({
             onMouseEnter={() => setMoreHover(true)}
             onMouseLeave={() => setMoreHover(false)}
             onClick={handleDropdownToggle}
-            className="rounded-[1.2rem] p-[0.8rem] hover:bg-neutral-98 focus:bg-neutral-95"
+            className="cursor-pointer rounded-[1.2rem] p-0 hover:bg-neutral-98 focus:bg-neutral-95"
           >
-            <IcMore width={32} height={32} className="text-neutral-50" />
+            <IcMore className="h-[3.2rem] w-[3.2rem] text-neutral-50" />
           </button>
           {/* 드롭다운 */}
           <ActionOption.Menu isOpen={isDropdownOpen}>


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 보드 목록 페이지 반응형

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

| 2 col | 3 col |
| - | - |
| <img width="2282" height="2064" alt="CleanShot 2025-08-23 at 12 34 04@2x" src="https://github.com/user-attachments/assets/7d4040da-b135-426d-948d-37e78d9cf2a9" /> | <img width="3600" height="2064" alt="CleanShot 2025-08-23 at 12 34 13@2x" src="https://github.com/user-attachments/assets/10e4f584-570e-4bae-80b4-7f312f087a21" /> | 


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * 대시보드 트립 보드 레이아웃을 반응형 그리드로 개선(최대 XL 2열, XL 이상 3열)하고 작은 화면에서 간격 축소.
  * ActionCard의 최소 너비 제약 제거로 다양한 화면에서 레이아웃 유연성 향상.
  * TravelBoard 컨테이너 최소 너비 제거 및 수직 패딩 정리로 공간 활용 개선.
  * 헤더 버튼에 커서 표시 추가, 불필요한 패딩 제거, 아이콘 크기를 클래스 기반으로 통일해 일관된 표시.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->