### PR TITLE
[Y26W2-398] fix(ui): 여행 보드 생성 관련 QA 반영

### DIFF
--- a/apps/web/src/domains/dashboard/components/board-create-form/index.tsx
+++ b/apps/web/src/domains/dashboard/components/board-create-form/index.tsx
@@ -23,13 +23,6 @@ const BoardCreateForm = ({ className }: BoardCreateFormProps) => {
   });
 
   const { handleSubmit, watch, control } = useForm<BoardCreateFormData>({
-    defaultValues: {
-      destination: "",
-      dateRange: {
-        from: new Date(),
-        to: new Date(new Date().setDate(new Date().getDate() + 1)),
-      },
-    },
     mode: "onChange",
   });
 

--- a/apps/web/src/domains/dashboard/components/board-create-form/index.tsx
+++ b/apps/web/src/domains/dashboard/components/board-create-form/index.tsx
@@ -23,6 +23,13 @@ const BoardCreateForm = ({ className }: BoardCreateFormProps) => {
   });
 
   const { handleSubmit, watch, control } = useForm<BoardCreateFormData>({
+    defaultValues: {
+      destination: "",
+      dateRange: {
+        from: undefined,
+        to: undefined,
+      },
+    },
     mode: "onChange",
   });
 

--- a/packages/ui/src/components/date-range-picker/index.tsx
+++ b/packages/ui/src/components/date-range-picker/index.tsx
@@ -95,16 +95,29 @@ const DateRangePicker = ({
     if (!selected) {
       return;
     }
+    const { from: selectedFrom, to: selectedTo } = selected;
+    const { from: currentFrom, to: currentTo } = value || {};
 
+    // 여행 시작일 handler
     if (activeField === "from") {
-      if (selected.from) {
-        setFrom(selected.from);
-        // from 선택 후 to로 자동 전환
-        if (!value.to || selected.from > value.to) {
-          setActiveField("to");
-        }
+      // 시작일이 to로 들어간 경우 (기존 from 이 존재하는 경우)
+      const isSameFrom = currentFrom?.getTime() === selectedFrom?.getTime();
+
+      if (isSameFrom) {
+        const shouldResetTo = selectedTo && currentTo && selectedTo > currentTo;
+
+        if (shouldResetTo) onChange({ from: selectedTo, to: selectedTo });
+        else setFrom(selectedTo ?? currentTo);
+      } else if (selectedFrom) {
+        // 시작일이 from 으로 들어간 경우
+        onChange({ from: selectedFrom, to: selectedFrom });
       }
-    } else if (activeField === "to") {
+
+      setActiveField("to");
+      return;
+    }
+    // 여행 종료일 handler
+    if (activeField === "to") {
       if (selected.to || selected.from) {
         setTo(selected.to || selected.from);
       }
@@ -117,7 +130,7 @@ const DateRangePicker = ({
         from: (
           <DateButton
             ref={refs.from}
-            value={value.from}
+            value={value?.from}
             placeholder={placeholder.from}
             onClick={() => openCalendar("from")}
             disabled={disabled}
@@ -126,7 +139,7 @@ const DateRangePicker = ({
         to: (
           <DateButton
             ref={refs.to}
-            value={value.to}
+            value={value?.to}
             placeholder={placeholder.to}
             onClick={() => openCalendar("to")}
             disabled={disabled}
@@ -137,7 +150,7 @@ const DateRangePicker = ({
         <div ref={floatingRef} style={floatingStyles} className="w-fit">
           <Calendar
             selectedDate={
-              value.from ? { from: value.from, to: value.to } : undefined
+              value ? { from: value?.from, to: value?.to } : undefined
             }
             onDateSelect={handleDateSelect}
             onApplyDate={closeCalendar}

--- a/packages/ui/src/components/date-range-picker/index.tsx
+++ b/packages/ui/src/components/date-range-picker/index.tsx
@@ -51,15 +51,19 @@ const DateRangePicker = ({
   const setActiveField = (field: "from" | "to" | null) => {
     setRawActiveField(field);
 
-    // reference 업데이트
     if (field === "from" && refs.from.current) {
+      // reference 업데이트
       referenceRef.current = refs.from.current;
     } else if (field === "to" && refs.to.current) {
       referenceRef.current = refs.to.current;
+    } else {
+      referenceRef.current = null;
     }
 
     refresh();
-    referenceRef.current?.focus();
+    if (field !== null) {
+      referenceRef.current?.focus();
+    }
   };
 
   useOutsideClickEffect(
@@ -80,7 +84,7 @@ const DateRangePicker = ({
 
   const closeCalendar = () => {
     setOpen(false);
-    setActiveField(null);
+    activeField === "to" ? setActiveField(null) : setActiveField("from");
   };
 
   const setFrom = (date: Date | undefined) => {


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- [about [Y26W2-398]](https://yapp26thweb2.atlassian.net/jira/software/projects/Y26W2/boards/1?selectedIssue=Y26W2-385) 
  -  캘린더 시작일 입력에 대한 UX를 개선했습니다  (종료일 선택 후, 시작일을 눌러야 하는 케이스 해결)
  -  해당 이슈의 원인은, react-day-pikcer의 경우 초기값이 존재 하는 경우, `to` 로 날짜가 설정되기 때문에 시작일과 종료일을 초기화 시켜주어야만 시작일을 고칠 수 있는 구조였습니다.
  -  이를 해결하기 위해 아래와 같이 로직을 수정했습니다.
   >  from 으로 시작일이 입력된 경우, `onChange({ from: selectedFrom, to: selectedFrom });`  (범위의 경우 한가지만 선택되면 range_start로 인식되지 않기 때문에 모두 초기화)
  >  to로 시작일이 입력된 경우 (이미 값이 등록되고 이후  시작일이 수정되는 경우), 기존 시작일과 새로 선택한 날짜가 동일한지 비교
  >  동일하다면 selectedTo > currentTo 일때 (새로운 시작일이 기존의 종료일 범위를 벗어나는 경우), =>  from과 to를 모두 초기화 
  >  그렇지 않다면 선택된 날짜를 기준으로 from 값을 재설정

추가로 자동으로 activeField를 "to"로 전환하여 종료일 선택 단계로 자연스럽게 이어지도록 UX를 개선했습니다.

-  [about [Y26W2-403]](https://yapp26thweb2.atlassian.net/jira/software/projects/Y26W2/boards/1?selectedIssue=Y26W2-403) 
  - 제목 입력에 제약조건이 따르지 않도록 수정해보았습니다 

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

[캘린더 시작일 / 종료일 이슈 해결]

https://github.com/user-attachments/assets/2c3f4f06-674a-4415-9765-47cd3579f48b



[여행 보드 제목 입력관련 이슈 해결]

https://github.com/user-attachments/assets/dc4a20cf-4c44-4cfe-b931-47a3dc7a47ec



## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->
