### PR TITLE
[Y26W2-404] feat(web): 비교표 생성을 위한, 숙소 선택 10개 제한

### DIFF
--- a/apps/web/src/domains/list/contexts/place-select-context.tsx
+++ b/apps/web/src/domains/list/contexts/place-select-context.tsx
@@ -33,22 +33,22 @@ const PlaceSelectionProvider = ({ children }: { children: ReactNode }) => {
 
   const togglePlaceSelect = useCallback(
     (id: number) => {
-      if (selectedPlaces.length >= 10) {
-        toast.success("최대 10개까지 선택할 수 있습니다.");
-        return;
-      }
-
       setSelectedPlaces((prev) => {
         const alreadySelected = prev.includes(id);
-        const updated = alreadySelected
-          ? prev.filter((placeId) => placeId !== id)
-          : [...prev, id];
-        return updated;
+        if (alreadySelected) {
+          return prev.filter((placeId) => placeId !== id);
+        }
+        if (prev.length >= 10) {
+          toast.success("최대 10개까지 선택할 수 있습니다.");
+          return prev;
+        }
+        return [...prev, id];
       });
+
       setLastSelectedPlace(id);
       if (!isPanelExpanded) handlePanelExpand();
     },
-    [selectedPlaces, isPanelExpanded, handlePanelExpand, toast.success],
+    [isPanelExpanded, handlePanelExpand, toast],
   );
 
   const onSelectPlace = useCallback(

--- a/apps/web/src/domains/list/contexts/place-select-context.tsx
+++ b/apps/web/src/domains/list/contexts/place-select-context.tsx
@@ -1,4 +1,5 @@
 "use client";
+import { useToast } from "@ssok/ui";
 import {
   createContext,
   type ReactNode,
@@ -22,6 +23,7 @@ const PlaceSelectionContext = createContext<PlaceSelectionContextType | null>(
 );
 
 const PlaceSelectionProvider = ({ children }: { children: ReactNode }) => {
+  const { toast } = useToast();
   const [selectedPlaces, setSelectedPlaces] = useState<number[]>([]);
   const [lastSelectedPlace, setLastSelectedPlace] = useState<number | null>(
     null,
@@ -31,6 +33,11 @@ const PlaceSelectionProvider = ({ children }: { children: ReactNode }) => {
 
   const togglePlaceSelect = useCallback(
     (id: number) => {
+      if (selectedPlaces.length >= 10) {
+        toast.success("최대 10개까지 선택할 수 있습니다.");
+        return;
+      }
+
       setSelectedPlaces((prev) => {
         const alreadySelected = prev.includes(id);
         const updated = alreadySelected
@@ -41,18 +48,23 @@ const PlaceSelectionProvider = ({ children }: { children: ReactNode }) => {
       setLastSelectedPlace(id);
       if (!isPanelExpanded) handlePanelExpand();
     },
-    [isPanelExpanded, handlePanelExpand],
+    [selectedPlaces, isPanelExpanded, handlePanelExpand, toast.success],
   );
 
   const onSelectPlace = useCallback(
     (id: number) => {
-      if (!selectedPlaces.includes(id)) {
-        setSelectedPlaces((prev) => [...prev, id]);
+      if (selectedPlaces.includes(id)) return;
+
+      if (selectedPlaces.length >= 10) {
+        toast.success("최대 10개까지 선택할 수 있습니다.");
+        return;
       }
+
+      setSelectedPlaces((prev) => [...prev, id]);
       setLastSelectedPlace(id);
       if (!isPanelExpanded) handlePanelExpand();
     },
-    [selectedPlaces, isPanelExpanded, handlePanelExpand],
+    [selectedPlaces, isPanelExpanded, handlePanelExpand, toast],
   );
 
   const removePlace = useCallback((id: number) => {


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 10개까지만 비교표 생성을 할 수 있도록 프론트 단에서 제한을 두었습니다 
(dev 환경에서는 strict 모드로 인해서 toast가 2번 도출됩니다 / strictMode false 일때 랜더링 1회 되는 것 확인했습니다! ) 
[관련 이슈 NOTION](https://www.notion.so/jisuuuu/10-27cca0b46ff28038bc24c3d0e109b8c4)

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

https://github.com/user-attachments/assets/c585b365-315d-483e-ae46-a320aaa3b6fc


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* New Features
  * 장소 선택을 최대 10개로 제한하고, 한도 도달 또는 초과 시 사용자에게 토스트 알림을 표시합니다.
* Bug Fixes
  * 이미 선택된 장소를 다시 추가하려는 시도를 무시해 중복 추가를 방지합니다.
* UX
  * 선택 제약과 즉각적인 토스트 피드백으로 선택 경험의 일관성과 명확성을 개선했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->