### PR TITLE
[Y26W2-405] fix(web): 리뷰 점수의 값 범위 제한

### DIFF
--- a/apps/web/src/domains/compare/components/compare-table/cleanliness-score-cell.tsx
+++ b/apps/web/src/domains/compare/components/compare-table/cleanliness-score-cell.tsx
@@ -1,6 +1,7 @@
 import { Graph } from "@ssok/ui";
 import { Controller, useFormContext } from "react-hook-form";
 import type { ComparisonFormData, ViewState } from "@/domains/compare/types";
+import { parseScore } from "@/domains/compare/utils/validation";
 
 export interface CleanlinessScoreCellProps {
   state: ViewState;
@@ -22,17 +23,16 @@ const CleanlinessScoreCell = ({ state, name }: CleanlinessScoreCellProps) => {
     <Controller
       control={control}
       name={name}
-      render={({ field }) => {
-        return (
-          <Graph
-            value={field.value || "0"}
-            label={getLabel(parseFloat(field.value || "0"))}
-            showGraph
-            state={state}
-            onChange={field.onChange}
-          />
-        );
-      }}
+      render={({ field }) => (
+        <Graph
+          value={field.value || "0"}
+          label={getLabel(parseFloat(field.value || "0"))}
+          showGraph
+          state={state}
+          onChange={(value) => field.onChange(parseScore(value))}
+          inputProps={{ type: "number", min: "0", max: "10", step: "0.1" }}
+        />
+      )}
     />
   );
 };

--- a/apps/web/src/domains/compare/components/compare-table/review-score-cell.tsx
+++ b/apps/web/src/domains/compare/components/compare-table/review-score-cell.tsx
@@ -1,6 +1,7 @@
 import { Graph, IcStarFull } from "@ssok/ui";
 import { Controller, useFormContext } from "react-hook-form";
 import type { ComparisonFormData, ViewState } from "@/domains/compare/types";
+import { parseScore } from "@/domains/compare/utils/validation";
 
 export interface ReviewScoreCellProps {
   state: ViewState;
@@ -22,18 +23,17 @@ const ReviewScoreCell = ({ state, name }: ReviewScoreCellProps) => {
     <Controller
       control={control}
       name={name}
-      render={({ field }) => {
-        return (
-          <Graph
-            value={field.value || "0"}
-            label={getLabel(parseFloat(field.value || "0"))}
-            icon={<IcStarFull />}
-            showGraph={false}
-            state={state}
-            onChange={field.onChange}
-          />
-        );
-      }}
+      render={({ field }) => (
+        <Graph
+          value={field.value || "0"}
+          label={getLabel(parseFloat(field.value || "0"))}
+          icon={<IcStarFull />}
+          showGraph={false}
+          state={state}
+          onChange={(value) => field.onChange(parseScore(value))}
+          inputProps={{ type: "number", min: "0", max: "10", step: "0.1" }}
+        />
+      )}
     />
   );
 };

--- a/apps/web/src/domains/compare/utils/validation.ts
+++ b/apps/web/src/domains/compare/utils/validation.ts
@@ -1,0 +1,22 @@
+/**
+ * 숫자 값을 지정된 범위로 제한합니다.
+ */
+export const clamp = (value: number, min: number, max: number): number => {
+  return Math.max(min, Math.min(max, value));
+};
+
+/**
+ * 문자열 점수를 파싱하고 값의 범위를 제한합니다.
+ */
+export const parseScore = (score: string, min = 0, max = 10): string => {
+  if (!score.trim()) {
+    return "";
+  }
+
+  const num = Number.parseFloat(score);
+  if (Number.isNaN(num)) {
+    return "";
+  }
+
+  return String(clamp(num, min, max));
+};

--- a/apps/web/tests/domains-compare-utils-validation.node.test.ts
+++ b/apps/web/tests/domains-compare-utils-validation.node.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from "vitest";
+import { clamp, parseScore } from "@/domains/compare/utils/validation";
+
+describe("clamp", () => {
+  it("범위 내 값은 그대로 반환", () => {
+    expect(clamp(5, 0, 10)).toBe(5);
+    expect(clamp(0, 0, 10)).toBe(0);
+    expect(clamp(10, 0, 10)).toBe(10);
+  });
+
+  it("최소값보다 작으면 최소값 반환", () => {
+    expect(clamp(-5, 0, 10)).toBe(0);
+    expect(clamp(-100, 0, 10)).toBe(0);
+  });
+
+  it("최대값보다 크면 최대값 반환", () => {
+    expect(clamp(15, 0, 10)).toBe(10);
+    expect(clamp(100, 0, 10)).toBe(10);
+  });
+});
+
+describe("parseScore", () => {
+  it("유효한 점수는 문자열로 반환", () => {
+    expect(parseScore("5")).toBe("5");
+    expect(parseScore("7.5")).toBe("7.5");
+    expect(parseScore("0")).toBe("0");
+    expect(parseScore("10")).toBe("10");
+  });
+
+  it("범위를 벗어난 값은 클램핑", () => {
+    expect(parseScore("-5")).toBe("0");
+    expect(parseScore("15")).toBe("10");
+    expect(parseScore("100")).toBe("10");
+  });
+
+  it("빈 문자열은 빈 문자열 반환", () => {
+    expect(parseScore("")).toBe("");
+    expect(parseScore("   ")).toBe("");
+  });
+
+  it("숫자가 아닌 값은 빈 문자열 반환", () => {
+    expect(parseScore("abc")).toBe("");
+    expect(parseScore(".!@#")).toBe("");
+  });
+
+  it("커스텀 min/max 범위 적용", () => {
+    expect(parseScore("5", 1, 5)).toBe("5");
+    expect(parseScore("0", 1, 5)).toBe("1");
+    expect(parseScore("10", 1, 5)).toBe("5");
+  });
+
+  it("소수점 값 처리", () => {
+    expect(parseScore("9.5")).toBe("9.5");
+    expect(parseScore("0.1")).toBe("0.1");
+    expect(parseScore("10.5")).toBe("10");
+  });
+});

--- a/packages/ui/src/components/graph/index.stories.tsx
+++ b/packages/ui/src/components/graph/index.stories.tsx
@@ -49,7 +49,7 @@ Default.args = {
 };
 
 export const WithGraph: StoryFn<GraphProps> = () => {
-  const [value, setValuee] = useState<string>("9.0");
+  const [value, setValue] = useState<string>("9.0");
 
   return (
     <div className="space-y-8">
@@ -84,7 +84,7 @@ export const WithGraph: StoryFn<GraphProps> = () => {
           value={value}
           label="매우 깨끗"
           state="edit"
-          onChange={setValuee}
+          onChange={setValue}
         />
       </div>
     </div>
@@ -92,7 +92,7 @@ export const WithGraph: StoryFn<GraphProps> = () => {
 };
 
 export const WithoutGraph: StoryFn<GraphProps> = () => {
-  const [value, setValuee] = useState<string>("9.0");
+  const [value, setValue] = useState<string>("9.0");
 
   return (
     <div className="space-y-8">
@@ -154,7 +154,7 @@ export const WithoutGraph: StoryFn<GraphProps> = () => {
           label="매우 좋음"
           icon={<IcStarFull />}
           state="edit"
-          onChange={setValuee}
+          onChange={setValue}
         />
       </div>
     </div>

--- a/packages/ui/src/components/graph/index.stories.tsx
+++ b/packages/ui/src/components/graph/index.stories.tsx
@@ -49,7 +49,7 @@ Default.args = {
 };
 
 export const WithGraph: StoryFn<GraphProps> = () => {
-  const [value, setValuee] = useState<number | null>(9.0);
+  const [value, setValuee] = useState<string>("9.0");
 
   return (
     <div className="space-y-8">
@@ -58,16 +58,16 @@ export const WithGraph: StoryFn<GraphProps> = () => {
         <div className="grid grid-cols-2 gap-4">
           <Graph
             showGraph={true}
-            value={9.5}
+            value="9.5"
             label="매우 깨끗"
             state="default"
           />
-          <Graph showGraph={true} value={7.5} label="깨끗" state="default" />
-          <Graph showGraph={true} value={5.0} label="보통" state="default" />
-          <Graph showGraph={true} value={3.0} label="나쁨" state="default" />
+          <Graph showGraph={true} value="7.5" label="깨끗" state="default" />
+          <Graph showGraph={true} value="5.0" label="보통" state="default" />
+          <Graph showGraph={true} value="3.0" label="나쁨" state="default" />
           <Graph
             showGraph={true}
-            value={1.0}
+            value="1.0"
             label="매우 나쁨"
             state="default"
           />
@@ -75,7 +75,7 @@ export const WithGraph: StoryFn<GraphProps> = () => {
       </div>
       <div className="space-y-4">
         <h3 className="font-semibold text-lg">Active State</h3>
-        <Graph showGraph={true} value={9.0} label="매우 깨끗" state="active" />
+        <Graph showGraph={true} value="9.0" label="매우 깨끗" state="active" />
       </div>
       <div className="space-y-4">
         <h3 className="font-semibold text-lg">Edit State</h3>
@@ -92,7 +92,7 @@ export const WithGraph: StoryFn<GraphProps> = () => {
 };
 
 export const WithoutGraph: StoryFn<GraphProps> = () => {
-  const [value, setValuee] = useState<number | null>(9.0);
+  const [value, setValuee] = useState<string>("9.0");
 
   return (
     <div className="space-y-8">
@@ -101,35 +101,35 @@ export const WithoutGraph: StoryFn<GraphProps> = () => {
         <div className="grid grid-cols-2 gap-4">
           <Graph
             showGraph={false}
-            value={9.5}
+            value="9.5"
             label="매우 좋음"
             icon={<IcStarFull />}
             state="default"
           />
           <Graph
             showGraph={false}
-            value={7.5}
+            value="7.5"
             label="좋음"
             icon={<IcStarFull />}
             state="default"
           />
           <Graph
             showGraph={false}
-            value={5.0}
+            value="5.0"
             label="보통"
             icon={<IcStarFull />}
             state="default"
           />
           <Graph
             showGraph={false}
-            value={3.0}
+            value="3.0"
             label="불만족"
             icon={<IcStarFull />}
             state="default"
           />
           <Graph
             showGraph={false}
-            value={1.0}
+            value="1.0"
             label="매우 불만족"
             icon={<IcStarFull />}
             state="default"
@@ -140,7 +140,7 @@ export const WithoutGraph: StoryFn<GraphProps> = () => {
         <h3 className="font-semibold text-lg">Active State</h3>
         <Graph
           showGraph={false}
-          value={9.0}
+          value="9.0"
           label="매우 좋음"
           icon={<IcStarFull />}
           state="active"

--- a/packages/ui/src/components/graph/index.tsx
+++ b/packages/ui/src/components/graph/index.tsx
@@ -11,6 +11,10 @@ export interface GraphProps
   showGraph?: boolean;
   icon?: ReactNode;
   onChange?: (value: string) => void;
+  inputProps?: Omit<
+    ComponentProps<"input">,
+    "value" | "onChange" | "className"
+  >;
 }
 
 const variants = cva(
@@ -39,6 +43,7 @@ const Graph = ({
   icon,
   showGraph = true,
   onChange,
+  inputProps,
   className,
   ...props
 }: GraphProps) => {
@@ -87,6 +92,7 @@ const Graph = ({
                 "[&>input]:[-moz-appearance:_textfield] [&>input]:[&::-webkit-inner-spin-button]:appearance-none [&>input]:[&::-webkit-outer-spin-button]:appearance-none",
                 text,
               )}
+              {...inputProps}
             />
           ) : (
             <span className={cn("text-body1-semi16", text)}>


### PR DESCRIPTION
## ✨ 변경 사항
<!-- 이 PR에서 어떤 작업이 이루어졌는지 간단히 설명해주세요 -->
- 리뷰 점수를 사용자가 직접 입력할 때, 입력하는 값의 범위가 0~10 외로 벗어나지 않도록 제한했습니다.

## ✅ 체크리스트

- [x] 기능 동작 확인
- [x] 코드 리뷰 반영
- [x] 테스트 통과
- [x] UI/UX 확인

## 📸 스크린샷 (선택)
<!-- UI 변경이 있다면 스크린샷을 첨부해주세요 -->

| as-is | to-be |
| - | - |
| <video src="https://github.com/user-attachments/assets/9f9f1211-a439-4315-90ff-6c13178cf8ea" /> | <video src="https://github.com/user-attachments/assets/3e9fd0c5-87e3-43ce-bf2c-d1514ed7c9c1" /> |


## 📝 기타 참고 사항
<!-- 리뷰어가 알아야 할 추가 정보가 있다면 작성해주세요 -->

<!-- ejoffe/spr start -->
<!-- ejoffe/spr end -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - 점수 편집 UI에서 숫자 입력이 0–10 범위, 0.1 단위로 제한되어 더 정확한 입력이 가능합니다.
  - 잘못된 또는 비어있는 입력은 자동으로 정규화되어 범위 내 값으로 보정됩니다.
  - 그래프 기반 점수 입력에 추가 입력 속성(inputProps) 지원이 추가되어 접근성 및 입력 동작 설정이 향상되었습니다.
- Tests
  - 점수 파싱과 범위 보정을 검증하는 단위 테스트를 추가해 신뢰성을 강화했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->